### PR TITLE
Land 001-superspec-baseline-T009 — GET /echo + SC-007 walkthrough evidence

### DIFF
--- a/.docs/onboarding-stopwatch.md
+++ b/.docs/onboarding-stopwatch.md
@@ -28,7 +28,48 @@
 
 ## 第一個 SDD feature 量測(T009 補充)
 
-_TODO(T009):在此新增「從 `/speckit-specify` 到第一個 feature PR 全綠」行,包含 SC-007 數值。_
+**完成日期**:2026-04-30
+**Sample feature**:`GET /echo` endpoint(`specs/001-superspec-baseline-T009/`)
+**Branch**:`001-superspec-baseline-T009`(從 `001-superspec-baseline` HEAD `8b699c7` fork,以
+`GIT_BRANCH_NAME` env 覆蓋預設 NNN-name 命名慣例)。
+**平台**:WSL2 Ubuntu host(本 maintainer dev 環境;Mac M1 上未重跑此 walkthrough)。
+
+### 整輪 SDD pipeline elapsed
+
+| 階段                 | 動作                                                                                            | 內容                                                                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `/speckit-specify`   | 產 `spec.md` + `checklists/requirements.md`                                                     | 5 user stories → 3 個 / 22 → 6 FRs / 11 → 5 SCs / 12 → 5 edge cases。0 個 [NEEDS CLARIFICATION] marker(以 Assumptions 段封閉所有歧義) |
+| `/speckit-clarify`   | **跳過**                                                                                        | spec 0 ambiguity → 直接進 plan                                                                                                        |
+| `/speckit-plan`      | 產 `plan.md` + `research.md` + `data-model.md` + `contracts/echo.contract.md` + `quickstart.md` | Constitution Check 5/5 ✅ no violations                                                                                               |
+| `/speckit-tasks`     | 產 `tasks.md`                                                                                   | 12 tasks / 6 phases / TDD mandatory                                                                                                   |
+| `/speckit-implement` | T001-T012                                                                                       | RED (T003) → GREEN (T004) → typecheck/lint/prettier 全綠 → manual quickstart 6 step → 收場                                            |
+| **合計**             | **21 min 5 sec(1265 s)**                                                                        | **遠小於 SC-007 ≤ 1 hour budget** ✅                                                                                                  |
+
+### 量測終點驗證
+
+- **`pnpm test`**:8 file / 27 tests pass(原 7 file 20 tests + 新 `tests/node/echo.test.ts` 7 cases — 3 happy / 3 missing / 1 metrics inheritance)
+- **`pnpm typecheck`**:exit 0
+- **`pnpm lint`**:exit 0(no-console rule:`/echo` handler 未引入 `console.*`)
+- **`pnpm exec prettier --check .`**:exit 0
+- **Quickstart manual walkthrough**:6 acceptance scenario 全綠(happy / URL-encoded / 中文 / missing / empty / multi-take-first);`/metrics` 含 `route="/echo"` counter + histogram bucket(自動繼承 baseline httpMetrics middleware,**無需顯式接線** — 兌現 spec FR-004 + 001 baseline observability invariant 1)
+- **`make down`** 收場乾淨
+
+### Implementation 規模
+
+- `src/node/app.ts` +9 lines(`app.get('/echo', handler)` + 註解)
+- `tests/node/echo.test.ts` 新檔 +96 lines(3 describe block / 7 it case + helper for register snapshot)
+- 對 baseline 既有檔案 / 契約 / 依賴 / 配置 **0 變更**
+
+### 兌現 001-superspec-baseline 之 SC-007
+
+> **SC-007**:Adopter 採用後的「第一個自家 feature」可在 1 小時內走完整 SDD pipeline
+> (`/speckit-specify → /speckit-clarify → /speckit-plan → /speckit-tasks → /speckit-implement`)
+> 且通過所有 quality gate;baseline 不預製範例 feature,SC-007 由 adopter 自家流程的可重現性驗證。
+
+本量測為本 maintainer 自跑的 SC-007 in-repo 實證。adopter 端可重現性需各自驗證,baseline 不 promise
+adopter 一定 ≤ 1 hour;但本 walkthrough 證明:**對 trivial 範圍 feature(1 endpoint,1 happy + 1 error
+分支),SC-007 budget 含寬裕緩衝(本次 21m,budget 60m)**,即使 adopter 較不熟悉 spec-kit 流程,
+仍有充足時間慢慢走。
 
 ## Fresh-eyes 二次驗證(T016 補充)
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/001-superspec-baseline"
-}
+{"feature_directory":"specs/001-superspec-baseline-T009"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,19 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/001-superspec-baseline/plan.md` (Implementation Plan for the
-SuperSpec Worker Monorepo Baseline). Phase 1 design artifacts:
+at `specs/001-superspec-baseline-T009/plan.md` (GET /echo endpoint —
+SC-007 walkthrough sample, branching off 001-superspec-baseline).
+Phase 1 design artifacts:
 
-- `specs/001-superspec-baseline/spec.md` — feature specification
-- `specs/001-superspec-baseline/research.md` — Phase 0 (clarifications + 22 FR gap analysis)
-- `specs/001-superspec-baseline/data-model.md` — Phase 1 (8 governance entities)
-- `specs/001-superspec-baseline/contracts/` — Phase 1 (5 contracts:
-  cli-pipeline, devcontainer, observability, quality-gates, sensitive-material)
-- `specs/001-superspec-baseline/quickstart.md` — Phase 1 (adopter walkthrough)
+- `specs/001-superspec-baseline-T009/spec.md` — feature specification
+- `specs/001-superspec-baseline-T009/research.md` — Phase 0 (no unknowns; cite baseline decisions)
+- `specs/001-superspec-baseline-T009/data-model.md` — Phase 1 (no entity; stateless echo)
+- `specs/001-superspec-baseline-T009/contracts/echo.contract.md` — Phase 1 endpoint contract
+- `specs/001-superspec-baseline-T009/quickstart.md` — Phase 1 (manual verify of 6 acceptance scenarios)
+
+Background / parent baseline:
+
+- `specs/001-superspec-baseline/` — full baseline spec / plan / contracts (merged to main)
 - `.specify/memory/constitution.md` — project constitution v1.0.0
   (Node + Worker dual-runtime principles)
 - `.docs/20260430a-cloudflare-worker.md` — design notes for the upcoming

--- a/specs/001-superspec-baseline-T009/checklists/requirements.md
+++ b/specs/001-superspec-baseline-T009/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: GET /echo Endpoint (SC-007 walkthrough)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — _Hono 與 prom-client 在 Assumptions 段明示,以連結至 001 baseline 既定棧為合理 default;FR 段未直接 reference 框架 API 名稱_
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders — _Hono / prom-client 連結屬於必要 traceability,非實作 leak_
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — _所有歧義皆於 Assumptions 段以合理 default 補足_
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic — _SC-001/002/003/005 純行為觀察;SC-004 cite 001 baseline 已有 ESLint rule(屬 baseline-level 既定治理,不算本 feature 新引入實作)_
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded — _「+1 route + 對應測試,無新依賴」明示_
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- 本 feature 為 SC-007 walkthrough 範例,**目的是兌現 ≤ 1 hour SDD pipeline timing**;規格刻意精簡,不引入新依賴 / 不變更既有契約。
+- `/speckit-clarify` 預期回覆「無 ambiguity 待釐清」直接建議 `/speckit-plan`(因所有 ambiguity 在 spec 中已用 Assumptions 補足)。

--- a/specs/001-superspec-baseline-T009/contracts/echo.contract.md
+++ b/specs/001-superspec-baseline-T009/contracts/echo.contract.md
@@ -1,0 +1,78 @@
+# Contract: `GET /echo` Endpoint
+
+**Audience**: API consumer / integration tests / 後續 derivative
+**Surface owner**: `src/node/app.ts`(handler)+ `tests/node/echo.test.ts`(verification)
+**Related FR / SC**: spec.md FR-001 ~ FR-006 / SC-001 ~ SC-005
+
+## Request
+
+| 屬性 | 值 |
+| --- | --- |
+| Method | `GET` |
+| Path | `/echo` |
+| Query parameters | `msg`(string,**required**;空字串等同 missing) |
+| Headers | 不要求特定 header(非 auth、非 Content-Type 限制) |
+| Body | 無(GET 慣例) |
+
+## Response — Success(200)
+
+| 屬性 | 值 |
+| --- | --- |
+| Status | `200 OK` |
+| Content-Type | `application/json`(由 Hono `c.json()` 自動設定) |
+| Body | `{ "message": "<msg 解碼後值>" }`(單一 key,字串 value) |
+
+範例:
+
+- Request: `GET /echo?msg=hello` → `{"message":"hello"}`
+- Request: `GET /echo?msg=hello%20world` → `{"message":"hello world"}`
+- Request: `GET /echo?msg=%E4%BD%A0%E5%A5%BD` → `{"message":"你好"}`
+
+## Response — Error(400)
+
+| 屬性 | 值 |
+| --- | --- |
+| Status | `400 Bad Request` |
+| Content-Type | `application/json` |
+| Body | `{ "error": "missing msg" }`(字面英文小寫) |
+
+觸發條件:
+
+- `msg` query parameter 缺失(`GET /echo`)
+- `msg` 為空字串(`GET /echo?msg=`)
+
+## 不變量(must)
+
+1. **route label = `"/echo"`**:metrics middleware 對此 route 之樣本 `route` label 必為字面 `/echo`,非 `not_found` 亦非 `unknown`(per 001 baseline observability.md §1.3 不變量 1-2)。
+2. **status_code label 隨實際 response status**:200 / 400 各自對應 metrics counter / histogram 之 `status_code` label。
+3. **Content-Type 始終 application/json**:無論 200 或 400,皆為 JSON;不可回 plain text 或 HTML。
+4. **Stateless**:多次相同 request 必回相同 response(冪等);不持久化任何狀態。
+5. **不污染 stdout**:handler 內若需 log,用 `pino` logger;絕不 `console.*`(per SC-009)。
+
+## 失敗模式
+
+| 場景 | 期望行為 |
+| --- | --- |
+| `?msg=` 空字串 | 400 + `{"error":"missing msg"}`(不因 query 存在但 value 為空而誤判合法) |
+| `?msg=a&msg=b`(多重) | 200 + `{"message":"a"}`(取第一,per Hono 預設) |
+| `POST /echo` 等非 GET | Hono 預設 405 / 404(不顯式註冊其他 method) |
+| 大量 msg(超 reverse proxy URI 上限) | 414 URI Too Long(由上游基礎建設處理,非本 contract 範疇) |
+| `HTTP_METRICS_ENABLED=false` 啟用 | `/echo` 仍 200 / 400 行為不變;只是 `/metrics` 不再有 `route="/echo"` 樣本 |
+
+## Test 驗證點(對應 `tests/node/echo.test.ts`)
+
+| Test case | 對照 contract |
+| --- | --- |
+| `GET /echo?msg=hello` → 200 + body 比對 | success path、Content-Type、body shape |
+| `GET /echo` → 400 + body 比對 | error path、Content-Type、`error` 字面值 |
+| `GET /echo?msg=` → 400 + body 比對 | empty-string 等同 missing |
+| `GET /echo?msg=hello` 後 `GET /metrics` 含 `route="/echo"` | 不變量 1(route label inheritance) |
+| 無 `console.*` 出現於 src/node/app.ts 對應 echo handler | 不變量 5(由 ESLint `no-console` 機械擋,本 test 為人類 review) |
+
+## 對 derivative 的 advisory
+
+替換 framework 後(per 001 baseline FR-018 derivative 契約),adopter 須:
+
+- 仍提供 `/echo` 等價 endpoint;若 framework 變動使 `c.req.query()` 等 API 名變,本 contract 之
+  「行為定義」(input → output mapping)依然 binding。
+- 若刪除 `/echo` 屬本 sample feature 接受(per spec.md preamble),不違反任何 baseline 規範。

--- a/specs/001-superspec-baseline-T009/data-model.md
+++ b/specs/001-superspec-baseline-T009/data-model.md
@@ -1,0 +1,40 @@
+# Phase 1 Data Model: GET /echo Endpoint
+
+**Date**: 2026-04-30
+**Spec**: [spec.md](./spec.md) — see "Key Entities" section
+**Plan**: [plan.md](./plan.md)
+
+> **Note**:本 feature 為純 stateless echo endpoint,**無持久化資料 / 無 entity / 無 schema**。
+> 此檔僅作為 SDD pipeline 完整性形式存在(spec-kit 流程要求每個 feature 有 data-model.md,
+> 即便為空亦顯式記錄「為何空」)。
+
+## Process / API Entities(暫態,僅 request lifetime)
+
+僅有兩個暫態結構,生命週期 = 一次 HTTP request 處理時間:
+
+### EchoRequest(讀取自 query string)
+
+- **fields**:
+  - `msg`:`string \| undefined`(由 `c.req.query('msg')` 回傳)
+- **驗證規則**:`msg !== undefined && msg !== ''` → 視為合法;否則回 400
+- **持久化**:無
+
+### EchoResponseBody(JSON,2 種 variant)
+
+- **Success variant**:`{ "message": string }` — value 為 `EchoRequest.msg` 之忠實 echo
+- **Error variant**:`{ "error": "missing msg" }` — 字面字串,英文小寫,client 可 string-equality match
+
+## Relationships
+
+無 — endpoint 不涉資料間關係,單一 in→out 映射。
+
+## State Transitions
+
+無 — endpoint 為 stateless,無生命週期狀態機。
+
+## 為何 data-model.md 在此仍存在
+
+per `.specify/templates/plan-template.md` `### Documentation (this feature)` 結構,data-model.md 為
+expected artifact;省略會讓 `/speckit-analyze` 跨 artifact 一致性掃描標 missing。本檔以
+explicit「無 entity」聲明取代省略,讓 derivative auditors 一眼可確認此 feature 為純 stateless,
+而非「漏寫 data model」。

--- a/specs/001-superspec-baseline-T009/plan.md
+++ b/specs/001-superspec-baseline-T009/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: GET /echo Endpoint (SC-007 walkthrough)
+
+**Branch**: `001-superspec-baseline-T009` | **Date**: 2026-04-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-superspec-baseline-T009/spec.md`
+
+## Summary
+
+新增單一無狀態 HTTP route `GET /echo` 於既有 Node 應用,讀取 query string `msg` 後回應 JSON。
+缺少或空 msg → 400 + `{"error":"missing msg"}`。實作為 1 個 handler + 對應 vitest 4 測試,
+**不引入新依賴**、**不變更既有契約**。本 feature 雙重身份兼具 SC-007 walkthrough 範例
+(driving Task T009 of 001-superspec-baseline)。
+
+**技術取徑**:Hono 4.x `app.get('/echo', handler)` 樣式;handler 內 `c.req.query('msg')`
+取值;空 / undefined → 400;否則 200。route 自動繼承既有 http-metrics middleware(掛在 `/*`),
+無需顯式接線。測試走 Hono `app.request()` mode(同 `tests/node/http-metrics.*.test.ts` 既有
+慣例),不啟動真實 server。
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.7+(strict),沿用 baseline。
+**Primary Dependencies**: Hono 4.x(已存於 `package.json` `dependencies`)— 新 feature 不增不減。
+**Storage**: N/A — `/echo` 為純 stateless echo,不觸 db / redis / KV。
+**Testing**: vitest 4.x;新增 `tests/node/echo.test.ts` 走 `app.request()` 模式,涵蓋 happy / 400 / metrics inheritance / log 不污染 console。
+**Target Platform**: Node.js ≥ 22,於 dev container 內透過 `pnpm dev` 或 `docker compose up app`;production 行為不變(同 multi-stage Dockerfile)。
+**Project Type**: Monorepo 內的 Node application(`src/node/`)單檔修補 + 單檔測試新增。
+**Performance Goals**: 100% 之 happy path < 5 ms server-side(Hono 處理 + 無 IO);完全位於 `/health` 同量級 budget 下。
+**Constraints**:
+
+- **不可** 在 Node 應用碼引入 `console.*`(per 001 baseline SC-009;ESLint `no-console: error` 已機械擋下)。
+- **不可** 引入新 npm 依賴(per spec.md「不引入新依賴」)。
+- **必須** 兌現 metrics 自動繼承(US3 / FR-005);若需顯式手寫 metrics 樣板,即代表 baseline observability invariant 1 已破。
+- **必須** 通過 mandatory gates(`pnpm test/typecheck/lint/prettier --check`);RED→GREEN→REFACTOR 紀律。
+
+**Scale/Scope**: 1 route,僅 happy + 1 error branch;測試覆蓋 ≥ 4 cases(HAPPY、400、metrics 繼承、無 console)。
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+依憲法 v1.0.0 五原則對照:
+
+| Principle | 對齊狀態 | 證據 / 對應 |
+| --- | --- | --- |
+| **I. Test-First Development (NON-NEGOTIABLE)** | ✅ | Phase 1 contracts/ 將先列 echo.contract.md 描述 endpoint 行為;Phase 2 tasks 將要求先寫 `tests/node/echo.test.ts`(RED)再實作 `app.get('/echo', ...)`(GREEN)。 |
+| **II. Observability by Default** | ✅ | 不顯式接 metrics — 完全依賴 baseline `httpMetrics()` middleware closure 自動覆蓋(observability.md §1.3 不變量 1)。pino logger 走預設管道。 |
+| **III. Container-First Development, Per-Runtime Deployment** | ✅ | route 落在 `src/node/app.ts`,於既有 Node 應用 image 內;不影響 Worker(本 feature 屬 Node-only,Worker 端無 echo 對等;若 002 需要可單獨增)。 |
+| **IV. Type Safety End-to-End** | ✅ | handler 簽名沿用 Hono `(c: Context) => Response` 慣例;`c.req.query('msg')` 回傳 `string \| undefined`,TypeScript 強制處理 undefined 分支;不需 cast 或 type assertion。 |
+| **V. Spec-Driven Development** | ✅ | 本 plan 即 SDD pipeline 產物;feature branch `001-superspec-baseline-T009` 由 `before_specify` hook(GIT_BRANCH_NAME 覆蓋)建立;spec checklist 16/16 全綠;`/speckit-implement` 前的人類 review gate 由 user(本 maintainer)親自 review。 |
+
+**結論**:無 violations,Phase 0 可放行。Plan 不引入任何 deviation,因此 Complexity Tracking 留空。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-superspec-baseline-T009/
+├── plan.md                  # 本檔
+├── spec.md                  # /speckit-specify 輸出
+├── research.md              # Phase 0 輸出 — 本 feature 因無 unknowns,research 主要 cite baseline 既有決策
+├── data-model.md            # Phase 1 輸出 — N/A(stateless,無 entity);只放一份 minimal note
+├── quickstart.md            # Phase 1 輸出 — adopter 如何手動驗證
+├── contracts/
+│   └── echo.contract.md     # Phase 1 輸出 — endpoint contract(input / output / error)
+├── checklists/
+│   └── requirements.md      # spec quality checklist
+└── tasks.md                 # Phase 2 輸出 — 由 /speckit-tasks 產生(本指令不建)
+```
+
+### Source Code (repository root)
+
+本 feature 僅修補既有 Node 應用內 1 檔 + 新增 1 測試:
+
+```text
+src/node/
+├── app.ts            # 既有檔,本 feature 於此新增 app.get('/echo', handler) 一段
+├── index.ts          # 不動
+├── db.ts             # 不動
+├── redis.ts          # 不動
+├── logger.ts         # 不動
+├── metrics.ts        # 不動
+└── http-metrics.ts   # 不動(/echo 自動繼承)
+
+tests/node/
+├── echo.test.ts      # 【新增】4+ cases:happy / 400 / metrics inheritance / no console pollution
+├── health.test.ts    # 不動
+├── metrics.test.ts   # 不動
+└── http-metrics.*.ts # 不動
+```
+
+**Structure Decision**:單檔修補(`src/node/app.ts`)+ 單測試新增(`tests/node/echo.test.ts`)。
+不新增 module、不抽 helper、不變更現有 import graph;遵守 SC-007 walkthrough 之精簡精神。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+(無 violation;本 feature 與五原則完全對齊)

--- a/specs/001-superspec-baseline-T009/quickstart.md
+++ b/specs/001-superspec-baseline-T009/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart: GET /echo Endpoint(SC-007 walkthrough)
+
+**Audience**: Adopter / 後續 walkthrough 計時人
+**Goal**: 從本 feature 已 implement 完成的狀態,手動驗證 6 個 acceptance scenario,確認與
+contracts/echo.contract.md 一致。
+
+> 預期 elapsed:**< 5 分鐘**(不含等待 stack 啟動)。本 quickstart 僅驗 functional 行為,不
+> 涉 SDD pipeline 計時(後者由 `.docs/onboarding-stopwatch.md` 「第一個 SDD feature」段紀錄)。
+
+## Step 0 — 前置
+
+- 本 feature 已 implement 完成(`/speckit-implement` 已跑完,所有 quality gates 綠)。
+- Node 應用 stack 啟動:`make up`(在 dev container 內或 host 直接跑)。
+- 三個 service 全綠 healthcheck(`docker compose ps` 看 healthy)。
+
+## Step 1 — Happy path
+
+```bash
+curl -sS 'http://localhost:8000/echo?msg=hello'
+```
+
+期望:
+
+```json
+{"message":"hello"}
+```
+
+HTTP status 200(可加 `-w '%{http_code}'` 顯式驗證)。
+
+## Step 2 — URL-encoded msg
+
+```bash
+curl -sS 'http://localhost:8000/echo?msg=hello%20world'
+```
+
+期望:`{"message":"hello world"}`(空白被 framework decode)。
+
+```bash
+curl -sS 'http://localhost:8000/echo?msg=%E4%BD%A0%E5%A5%BD'
+```
+
+期望:`{"message":"你好"}`(中文 UTF-8 decode)。
+
+## Step 3 — 缺少 msg → 400
+
+```bash
+curl -sS -w ' HTTP %{http_code}\n' 'http://localhost:8000/echo'
+```
+
+期望:`{"error":"missing msg"} HTTP 400`。
+
+```bash
+curl -sS -w ' HTTP %{http_code}\n' 'http://localhost:8000/echo?msg='
+```
+
+期望同上(空字串等同 missing)。
+
+## Step 4 — 多重 msg 取第一
+
+```bash
+curl -sS 'http://localhost:8000/echo?msg=a&msg=b'
+```
+
+期望:`{"message":"a"}`(per spec.md Assumption 3)。
+
+## Step 5 — Metrics 自動繼承
+
+對 `/echo` 至少 hit 過一次後:
+
+```bash
+curl -sS http://localhost:8000/metrics | grep '"/echo"'
+```
+
+期望(節錄):
+
+```
+http_requests_total{method="GET",route="/echo",status_code="200"} 1
+http_requests_total{method="GET",route="/echo",status_code="400"} 2
+http_request_duration_seconds_bucket{...,route="/echo",...} <bucket count>
+http_request_duration_seconds_count{method="GET",route="/echo",status_code="200"} 1
+http_request_duration_seconds_sum{method="GET",route="/echo",status_code="200"} <total seconds>
+```
+
+關鍵觀察點:
+
+- `route` label 必為字面 `"/echo"`,非 `unknown` 亦非 `not_found`。
+- counter 與 histogram 都有對應 `/echo` 樣本(US3 + FR-005)。
+
+## Step 6 — Opt-out 行為
+
+```bash
+HTTP_METRICS_ENABLED=false make up   # 重啟 stack 帶這個 env(或編輯 .env 後 make up)
+curl -sS http://localhost:8000/echo?msg=hello   # 仍 200 + 正確 body
+curl -sS http://localhost:8000/metrics | grep '"/echo"' || echo "no /echo metric"
+```
+
+期望:`/echo` 行為不變(仍 200 + body),但 `/metrics` 不再有 `route="/echo"` 樣本(per
+contract 失敗模式表最後一列)。
+
+## Step 7 — Stack 收場
+
+```bash
+make down
+```
+
+容器停掉,volumes 保留(若你想下次繼續用既有 db / redis state)。
+
+## Acceptance — 你完成了嗎?
+
+- [ ] Step 1 happy path 200 + 正確 body
+- [ ] Step 2 URL-encoded 解碼正確
+- [ ] Step 3 缺 msg → 400 + 正確 body
+- [ ] Step 4 多重 msg 取第一
+- [ ] Step 5 metrics 含 `route="/echo"`
+- [ ] Step 6 opt-out 行為符合預期
+
+✅ 全部勾選 → 本 sample feature 兌現 spec.md 全 5 SC,並驗證 001 baseline observability invariant
+仍 holding(SC-004 跨 feature 仍綠)。

--- a/specs/001-superspec-baseline-T009/research.md
+++ b/specs/001-superspec-baseline-T009/research.md
@@ -1,0 +1,48 @@
+# Phase 0 Research: GET /echo Endpoint (SC-007 walkthrough)
+
+**Date**: 2026-04-30
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+## Section 1 — Unknowns(無)
+
+本 feature 為 trivial endpoint,所有歧義已於 spec.md `## Assumptions` 段以合理 default 補足:
+
+1. Hono 4.x query string 解析語意 — `c.req.query('msg')` 回傳第一個值(若多個);
+2. 空字串 `?msg=` 視為 missing — 對應 spec FR-003 / Assumption 2;
+3. URL-encoded 字元由 framework 自動解碼 — Hono 內建。
+
+無 `[NEEDS CLARIFICATION]` marker 待解。
+
+## Section 2 — 既有 baseline 決策複用(cite,不重 derive)
+
+| 決策 | 來源 | 對本 feature 之影響 |
+| --- | --- | --- |
+| Hono 4.x 為 web framework | `.specify/memory/constitution.md` §Technology Stack(Shared 段)+ 001 baseline plan §Technical Context | `app.get('/echo', handler)` 註冊樣式 |
+| http-metrics middleware 掛 `/*` | `001-superspec-baseline/contracts/observability.md` §1.4 不變量 1(`src/node/app.ts:19`)+ `httpMetrics()` factory(`src/node/http-metrics.ts:120`) | `/echo` 自動繼承,不需顯式接線 |
+| pino structured log 為唯一 stdout 通道 | constitution v1.0.0 §II Observability + 001 baseline FR-006 / SC-009 | handler 內若需 log → 用 `logger.info({...})`;絕不 `console.*` |
+| `no-console: error` ESLint rule on `src/**/*.ts` | `eslint.config.js`(已 verify by 001 baseline T002) | 機械擋下 `console.*`,SC-009 自動兌現 |
+| vitest 4 + Hono `app.request()` 測試 mode | 既有 `tests/node/http-metrics.test.ts` 等實證 | `tests/node/echo.test.ts` 採同模式,不啟真實 server |
+| TypeScript strict mode + `c.req.query()` 回傳 `string \| undefined` | `tsconfig.json` strict + Hono types | handler 強制處理 undefined 分支(TS-level) |
+
+## Section 3 — 替代方案(已評估後 reject)
+
+| 替代方案 | 為何 reject |
+| --- | --- |
+| 用 `c.req.queries('msg')` 取所有 msg 值並返回 array | 違反 spec.md Assumption 3「取第一個值」;且超出 SC-007 trivial 邊界 |
+| 用 zod / valibot 做 schema 驗證 | 引入新依賴;違反 spec.md「不引入新依賴」;`if (!msg) return 400` 已足夠 trivial 驗證 |
+| 把 msg 長度上限明列為 spec 規則 | 上層 reverse proxy / Node http parser 已有預設(典型 8 KB URI / 8 MB body);Hono level 不需加;reject(per spec edge case 註) |
+| 改用 POST /echo 接收 body | spec 明示 GET + query string;若需 POST 屬不同 feature scope |
+| 把 `/echo` 直接放 dev `routes/` sub-folder 而非 `app.ts` 註冊 | 既有 baseline 沒有 sub-route 拆分慣例(`/`、`/health`、`/metrics` 都直接在 `app.ts`);拆分屬重構,超出 trivial scope |
+
+## Section 4 — Out of Scope(刻意不做)
+
+- **rate limiting / auth on /echo**:per spec.md Assumption 4,public endpoint mode,adopter 自行於 reverse proxy 加。
+- **OpenAPI / Swagger 自動文件**:001 baseline 未引入 OpenAPI 工具鏈,本 feature 不破例;`echo.contract.md` 為人類可讀格式即可。
+- **i18n 錯誤訊息**:`{"error":"missing msg"}` 字面英文;若 derivative 需 i18n 屬上層擴充。
+- **request id / correlation 透過 echo response 回顯**:屬未來 observability 增強,非本 feature 範疇。
+
+## Section 5 — 結論
+
+無 unknowns 待解;本 plan 於 Phase 1 直接產出 contracts/ + quickstart.md + 最小 data-model 紀錄,
+即可進入 `/speckit-tasks`。Phase 0 結束。

--- a/specs/001-superspec-baseline-T009/spec.md
+++ b/specs/001-superspec-baseline-T009/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: GET /echo Endpoint (SC-007 walkthrough sample)
+
+**Feature Branch**: `001-superspec-baseline-T009`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "在 Node 應用加一個 GET /echo endpoint,接受 query string ?msg=xxx,回傳 JSON {\"message\":\"xxx\"};若沒帶 msg 則回 400 + JSON {\"error\":\"missing msg\"}。屬於 SC-007 walkthrough 範例 feature,可在驗收後刪除。"
+
+> **本 feature 僅作為 001-superspec-baseline 之 SC-007 walkthrough 範例**(Task T009)。整段
+> SDD pipeline 跑完即視為 SC-007「第一個自家 feature ≤ 1 hour」量化證據;feature 本身可在驗收
+> 後保留為實證 anchor 或刪除。**對 Node baseline 應用程式之變更僅 +1 route + 對應測試**,
+> 不引入新依賴、不變更既有契約。
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - 開發者送 msg 參數收到 echo 結果 (Priority: P1)
+
+API 消費者(同一 monorepo 內的開發者或外部 client)送出 `GET /echo?msg=hello`,期望即刻收到
+`{"message":"hello"}` 之 JSON 回應(HTTP 200)。`msg` 內容為任意 URL-safe 文字,長度由
+框架預設與 reverse proxy 上限決定,本 feature 不另設限。
+
+**Why this priority**:此為 endpoint 之主要用途;失去此 happy path,feature 失去意義。
+
+**Independent Test**:任何 HTTP client(curl / fetch / browser)發送 `GET /echo?msg=<value>`
+即可獨立驗證 — 不需 db / redis / 任何 stateful component。
+
+**Acceptance Scenarios**:
+
+1. **Given** Node 應用 stack 已啟動(`make up` 全綠),**When** `curl -sS 'http://localhost:8000/echo?msg=hello'`,**Then** HTTP 200 + body `{"message":"hello"}`(欄位順序可不嚴格,但 key 名與 value 內容須完全相符)。
+2. **Given** 同上,**When** msg 含 URL-encoded 中文(`?msg=%E4%BD%A0%E5%A5%BD`),**Then** 200 + body `{"message":"你好"}`(框架負責解碼)。
+3. **Given** 同上,**When** msg 含空白(`?msg=hello%20world`),**Then** 200 + body `{"message":"hello world"}`。
+
+---
+
+### User Story 2 - 缺少 msg 參數收到 400 錯誤 (Priority: P1)
+
+API 消費者誤送 `GET /echo`(無 `msg` query string)時,期望立刻收到 HTTP 400 + 結構化
+JSON 錯誤訊息,而非 200 + 空字串或 5xx。提供一致、可被 client 自動化處理的錯誤格式。
+
+**Why this priority**:輸入驗證為 API 健壯性的最低限承諾;缺此分支即任何空 msg 都被當合法,
+退化為「default to empty string」之 silent footgun。
+
+**Independent Test**:`curl -sS -w '%{http_code}' 'http://localhost:8000/echo'` 即可驗證
+HTTP code = 400 + body 為預期 JSON,不需額外 setup。
+
+**Acceptance Scenarios**:
+
+1. **Given** Node 應用 stack 已啟動,**When** `curl -sS -w '%{http_code}' 'http://localhost:8000/echo'`,**Then** HTTP 400 + body `{"error":"missing msg"}`。
+2. **Given** 同上,**When** `curl -sS 'http://localhost:8000/echo?msg='`(空字串值),**Then** HTTP 400 + body `{"error":"missing msg"}`(empty 視為等同 missing,per Assumption 2)。
+3. **Given** 同上,**When** 多個 msg(`?msg=a&msg=b`),**Then** HTTP 200 + body 取第一個值(per Assumption 3)。
+
+---
+
+### User Story 3 - 新增 route 自動繼承 observability(Priority: P2)
+
+開發者新增 `/echo` 之後,**不需做任何 metrics 接線**,於 `/metrics` 1 分鐘內可見此 route 的
+counter 與 histogram 樣本(`route="/echo"`)。stdout 結構化 log 含此 request。
+
+**Why this priority**:此 feature 同時兌現 001 baseline 之 FR-006 / SC-004 承諾(observability
+default 自動繼承);若失敗即代表 baseline 規範本身崩盤,影響超過本 sample feature 範圍。
+但相對於 P1 之核心功能驗收,此項屬「順帶確認」性質,P2。
+
+**Independent Test**:對 `/echo?msg=test` 發 ≥ 1 次 request 後 `curl /metrics | grep '/echo'`,
+應見 `http_requests_total{...,route="/echo",...}` 與 `http_request_duration_seconds_bucket{...,route="/echo",...}`。
+
+**Acceptance Scenarios**:
+
+1. **Given** 應用啟動且 `/echo` 已被 hit 至少一次,**When** `curl /metrics | grep '"/echo"'`,**Then** 輸出含 `http_requests_total` counter 與 `http_request_duration_seconds_*` histogram(對應 route="/echo")。
+2. **Given** 設 `HTTP_METRICS_ENABLED=false` 並重啟,**When** 同上 grep,**Then** 0 hits(middleware 整段 short-circuit,per 001 baseline observability.md §1.2)。
+
+---
+
+### Edge Cases
+
+- **空 `msg` 值** 視為 missing(per Assumption 2);若 client 真需傳空字串,屬不在此 feature scope 之變更請求。
+- **重複 msg 參數**(`?msg=a&msg=b`)取第一個值,per Hono 預設 query parser(Assumption 3)。
+- **Non-UTF-8 byte sequence in msg**(非常見,通常被 client 端 encoding 攔下):由框架 / Node http parser 自然處理,本 feature 不顯式檢測。
+- **msg 過長** 超 reverse proxy 預設 URL 長度上限(典型 8 KB)時 414 URI Too Long,屬上層基礎建設行為,本 feature 不額外處理。
+- **non-GET method**(POST /echo 等)落在 Hono 預設 405 / 404 行為;本 feature 不顯式註冊其他 method handler。
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**:應用 MUST 暴露 path `/echo` 之 `GET` route,於 Node 應用主 router 註冊(同 `/health` `/metrics` 同層)。
+- **FR-002**:當 query string `msg` 存在且非空字串時,response MUST 為 HTTP 200 + JSON `{"message": "<msg 值>"}`,`message` 之值忠實反映 query string 解碼後內容,Content-Type `application/json`。
+- **FR-003**:當 query string `msg` 缺失或為空字串時,response MUST 為 HTTP 400 + JSON `{"error": "missing msg"}`,Content-Type `application/json`。`error` value 字面為 `missing msg`(英文小寫)以利自動化 client 比對。
+- **FR-004**:`/echo` route MUST 自動被 `http-metrics` middleware 涵蓋(per 001 baseline FR-006);不需於 `app.ts` 新加任何 metrics 樣板。
+- **FR-005**:`/echo` 之 metrics 樣本 `route` label MUST 為字面 `"/echo"`(模板路徑);非 `not_found` 亦非 `unknown`。
+- **FR-006**:`/echo` request / response 之 stdout log MUST 為 pino 預設結構化 JSON 一行(per 001 baseline FR-006);不可使用 `console.*`(per 001 baseline SC-009)。
+
+### Key Entities
+
+(本 feature 為純 stateless endpoint,**無 entity** — 不引入 db / redis schema、不操作 KV、不持久化任何狀態。)
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**:對 `GET /echo?msg=<任意非空字串>` 之請求,**100%** 回 HTTP 200 + 正確 JSON 結構;任何「200 + 錯誤 body」或「非 200」即視為失敗。
+- **SC-002**:對 `GET /echo`(無 msg)或 `GET /echo?msg=`(空 msg),**100%** 回 HTTP 400 + 正確 JSON 結構;任何「200 但空 message」或「500」即視為失敗。
+- **SC-003**:對 `/echo` 之首次成功請求落地後,**60 秒內** `/metrics` 必可見其 counter 與 histogram 樣本(per 001 baseline SC-004 之 1-minute budget)。
+- **SC-004**:`/echo` 自首次部署後 30 天內 ad-hoc `console.*` 出現次數 = 0(由 ESLint `no-console` rule 機械保證,per 001 baseline SC-009)。
+- **SC-005**:整輪 SDD pipeline(specify → clarify → plan → tasks → implement,本 feature 即 T009)在 ≤ 1 hour 內完成,**兌現 001 baseline SC-007**。
+
+## Assumptions
+
+1. **Hono 4.x 為應用 web framework**(per 001 baseline plan / Hono 為憲法 CORE),`app.get('/echo', handler)` 之註冊樣式不變;handler 內存取 `c.req.query('msg')` 取得 msg 值。
+2. **空字串等同 missing**:`?msg=` 視為「缺少」而非「以空字串作為合法 msg」。理由:HTTP 慣例上空字串難與 absence 區分(尤其經中介 proxy / cache 後),客戶端若刻意發空字串通常為錯誤。
+3. **多重 msg 取第一**:`?msg=a&msg=b` 取 `a`,per Hono 預設 query parser(`c.req.query('msg')` 回傳第一個值;若需全部需 `c.req.queries('msg')`)。
+4. **不引入 rate limiting / auth**:`/echo` 比照 `/health` `/metrics` 之 public endpoint 模式,無 auth、無 rate limit。derivative adopter 若需保護,自行於上游 reverse proxy 加。
+5. **prom-client metrics 對 `/echo` 自動生效**:基於 001 baseline observability.md §1.4 invariant 1(`/*` mount + middleware closure 自動覆蓋);不需在 plan 階段重新 derive。
+6. **Tests 使用 vitest 4 + Hono `app.request()`** 模式,如同既有 `tests/node/http-metrics.*.test.ts`;不引入新測試框架。
+
+## Dependencies
+
+- 上游依賴(已在 001 baseline 兌現):Hono 4.x、`@hono/node-server`、`prom-client`(per `package.json`)。
+- 規範依賴:001 baseline FR-006 / SC-004 / SC-009、constitution v1.0.0 §II Observability by Default、§I Test-First Development、§IV Type Safety End-to-End。
+- 無新外部 service / 新 npm 依賴。

--- a/specs/001-superspec-baseline-T009/tasks.md
+++ b/specs/001-superspec-baseline-T009/tasks.md
@@ -1,0 +1,203 @@
+---
+description: "Tasks: GET /echo endpoint (SC-007 walkthrough sample of 001-superspec-baseline)"
+---
+
+# Tasks: GET /echo Endpoint (SC-007 walkthrough)
+
+**Input**: Design documents from `/specs/001-superspec-baseline-T009/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/echo.contract.md, quickstart.md
+**Tests**: 本 feature **明示要求 TDD** — 對應 spec FR-005 / SC-001~SC-005、constitution v1.0.0 §I 不可協商。所有 implementation 任務都先有對應 RED test;此檔列為 mandatory tests。
+
+**Organization**: Tasks 依 spec.md 的 3 個 user stories 分相 phase。
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: 可平行(不同檔、無未完成依賴)
+- **[Story]**: 對應 spec.md user story(US1 happy / US2 400 / US3 metrics inheritance);跨 story / setup / polish 任務不帶 story label
+- 描述含絕對檔案路徑(repo-relative)
+
+## Path Conventions
+
+本 feature 為 monorepo 內 Node 應用單檔修補:`src/node/app.ts`(handler 註冊)+ `tests/node/echo.test.ts`(新增測試)。
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**:無新依賴 / 無新模組,本 phase 僅作 sanity 確認。
+
+- [X] T001 確認當前 branch 為 `001-superspec-baseline-T009`(`git branch --show-current`);確認 working tree 含 `specs/001-superspec-baseline-T009/{spec,plan,research,data-model,quickstart}.md` + `contracts/echo.contract.md`(已由 `/speckit-plan` 產出)。**對應 plan.md Project Structure**
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**:確認 baseline mandatory gates 在 implement 前已綠,作為 RED→GREEN 的起點(避免把先前 broken state 誤算成 feature regression)。
+
+**⚠️ CRITICAL**:完成此 phase 後 user story 才能進入 RED 階段
+
+- [X] T002 跑一次完整 mandatory gates 確認綠地起點:`pnpm install --frozen-lockfile` → `pnpm test`(預期 7 file / 20 tests pass)→ `pnpm typecheck`(exit 0)→ `pnpm lint`(exit 0)→ `pnpm exec prettier --check .`(exit 0)。任一失敗 STOP 調查(可能 main 後續 commit 引入 regression)。**對應 001 baseline FR-005 / FR-008 / FR-009 / FR-010**
+
+**Checkpoint**:基線綠地確認 — RED→GREEN 起點明確
+
+---
+
+## Phase 3: User Story 1 - Happy path GET /echo?msg=xxx (Priority: P1) 🎯 MVP
+
+**Goal**:`GET /echo?msg=hello` 回 200 + `{"message":"hello"}`,涵蓋 URL-encoded、中文、空白等 happy path 子情境。
+
+**Independent Test**:`curl -sS 'http://localhost:8000/echo?msg=hello'` 應 200 + body `{"message":"hello"}`。
+
+### Tests for User Story 1 (TDD mandatory) ⚠️
+
+> **NOTE**:Test 必須先寫 + RED 失敗 + 才寫 implementation
+
+- [X] T003 [P] [US1] 在 `tests/node/echo.test.ts` 新增 describe block "GET /echo - happy path",含至少 3 個 it case:(a) `?msg=hello` → 200 + `{"message":"hello"}`;(b) URL-encoded 空白 `?msg=hello%20world` → `{"message":"hello world"}`;(c) URL-encoded 中文 `?msg=%E4%BD%A0%E5%A5%BD` → `{"message":"你好"}`。使用 Hono `app.request()` mode(同 `tests/node/http-metrics.test.ts` 慣例)。**RED:tests fail (`pnpm test`),因 handler 未實作**
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] 在 `src/node/app.ts` 註冊 `app.get('/echo', handler)`;handler 內 `const msg = c.req.query('msg'); if (!msg) return c.json({error:'missing msg'}, 400); return c.json({message: msg});`(只實作 happy 分支,error 分支保留給 US2 但同檔不可避免一起寫;US2 RED test 將驗證 error 分支)。在現有 `app.get('/metrics', ...)` 之上、`app.get('/health', ...)` 之下任何位置即可,但**不可放在 `app.use(METRICS_MOUNT, ...)` 之前**(避免被 metrics middleware 跳過)。**GREEN:T003 tests pass**
+
+**Checkpoint**:US1 happy path 兌現,SC-001 (100% 200 + 正確 JSON) 機械驗證
+
+---
+
+## Phase 4: User Story 2 - Missing msg → 400 (Priority: P1)
+
+**Goal**:`GET /echo`(無 msg)或 `GET /echo?msg=`(空值)回 400 + `{"error":"missing msg"}`。
+
+**Independent Test**:`curl -sS -w '%{http_code}' 'http://localhost:8000/echo'` 應 HTTP 400 + body `{"error":"missing msg"}`。
+
+### Tests for User Story 2 (TDD mandatory) ⚠️
+
+- [X] T005 [P] [US2] 在 `tests/node/echo.test.ts` 新增 describe block "GET /echo - missing msg",含至少 3 個 it case:(a) `GET /echo` (無 query) → 400 + `{"error":"missing msg"}`;(b) `GET /echo?msg=` (空字串) → 400 + 同 body;(c) `GET /echo?msg=a&msg=b` → 200 + `{"message":"a"}`(per spec.md Assumption 3)。**注意**:T004 implementation 已包含 `if (!msg)` 邏輯,故 T005 可能直接 GREEN 而非 RED;若 GREEN 須在 PR description 顯式 declare「US2 與 US1 共享 implementation 檔,T005 RED 視同 T003 RED 階段」(無迴避 TDD 紀律,只是 same-file invariant)。**對應 spec FR-003 + Assumption 2 + 3**
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] 確認 T004 之 handler 已涵蓋 missing / empty msg 分支(`if (!msg)` 涵蓋 undefined + 空字串,因 JS truthy);若 T005 RED 觸發發現邏輯不足,於 `src/node/app.ts` echo handler 微調。**GREEN:T005 tests pass**
+
+**Checkpoint**:US2 兌現,SC-002 (100% 400 + 正確 JSON) 機械驗證
+
+---
+
+## Phase 5: User Story 3 - Metrics 自動繼承 (Priority: P2)
+
+**Goal**:`/echo` 自動被 http-metrics middleware 涵蓋,`/metrics` 1 分鐘內可見 `route="/echo"` counter + histogram。
+
+**Independent Test**:對 `/echo?msg=test` hit ≥ 1 次後 `curl /metrics | grep '"/echo"'` 應有 `http_requests_total{...,route="/echo",...}` + `http_request_duration_seconds_bucket{...,route="/echo",...}`。
+
+### Tests for User Story 3 (TDD mandatory) ⚠️
+
+- [X] T007 [P] [US3] 在 `tests/node/echo.test.ts` 新增 describe block "GET /echo - metrics inheritance",至少 1 個 it case:對 `/echo?msg=foo` 發 request 後,呼叫 register.metrics() 取得 prom-client 序列化文字,grep 應出現 `http_requests_total{...,route="/echo",...,status_code="200"}` 樣本。可參考 `tests/node/http-metrics.regression.test.ts` 的 register reset / metric snapshot 樣式。**對應 spec FR-004 / FR-005 / SC-003**
+
+### Implementation for User Story 3
+
+- [X] T008 [US3] **無需新 implementation** — 因 baseline `httpMetrics()` middleware 掛在 `/*`(per `src/node/app.ts:19`),只要 T004 的 handler 出現在 `app.use` 之後,自動繼承。本 task 為「驗證確認」性質:跑 T007 確保 GREEN;若 fail,代表 baseline observability invariant 1 已破(屬 `001-superspec-baseline` regression),須回頭修補 baseline 而非本 feature。
+
+**Checkpoint**:US3 兌現,SC-003 / SC-004 機械驗證
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**:跨 story 的最終一致性檢查 + manual quickstart 走查 + 計時收尾。
+
+- [X] T009 [P] 跑 `pnpm test` 全套(預期 7 file + 1 new file = 8 file / 20 + N tests pass,N ≥ 7 from new echo.test.ts)。**對應 quality-gates mandatory gate Tests**
+- [X] T010 [P] 跑 `pnpm typecheck`(exit 0)、`pnpm lint`(exit 0,no-console rule 確認 echo handler 無 `console.*`)、`pnpm exec prettier --check .`(exit 0)。**對應 quality-gates mandatory gates Types / Lint / Style**
+- [X] T011 跑一次 `make up`,手動走 quickstart.md Step 1-7(6 個 acceptance scenario + opt-out + 收場)。記錄 elapsed time 至 `.docs/onboarding-stopwatch.md`「第一個 SDD feature 量測(T009 補充)」段。**對應 spec SC-005 + 001 baseline SC-007 + T009 verification**
+- [X] T012 計算整輪 SDD pipeline elapsed:`date +%s` 終點 - `/tmp/t009-start.txt` 起點 / 60 = 分鐘數,記錄至 `.docs/onboarding-stopwatch.md`「第一個 SDD feature 量測」段(欄位:specify / clarify / plan / tasks / implement(T001-T010) / quickstart(T011) / 總計);若 ≤ 60 min 即達成 SC-007。**對應 spec SC-005 + 001 baseline SC-007**
+
+**Checkpoint**:001-superspec-baseline-T009 整輪交付完成,SC-007 ≤ 1 hour 量化證據就位。**Sample feature 之後可由 maintainer 決定 merge 至 main 作永久實證 anchor 或 `git branch -D` 刪除(per spec.md preamble)**
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**:無依賴
+- **Foundational (Phase 2)**:依賴 Phase 1;阻塞所有 user story
+- **US1 (Phase 3)**:依賴 Phase 2;為 MVP
+- **US2 (Phase 4)**:依賴 Phase 2 + 與 US1 共享 `src/node/app.ts` 檔(non-parallel against US1)
+- **US3 (Phase 5)**:依賴 Phase 2 + US1 已落地(因 metrics 觀察需 happy path 已可被觸發);與 US2 可並行寫測但驗證需序列
+- **Polish (Phase 6)**:依賴所有 US 完成
+
+### Within-Phase Dependencies
+
+- **T003 → T004**(RED → GREEN of US1)
+- **T005 → T006**(RED → GREEN of US2;T005 同檔覆蓋 T004 implementation)
+- **T007 → T008**(US3 只是驗證,GREEN 不需新 implementation)
+- **T009 / T010 → T011 → T012**(Polish 序列:gates → quickstart manual → 計時)
+
+### Parallel Opportunities
+
+- T003 ∥ T005 ∥ T007:不同 describe block 寫測試,可同時起手草稿(但都改同檔 `tests/node/echo.test.ts`,實際 commit 須序列;標 [P] 為「可獨立思考」非「可並行 commit」)。
+- T009 ∥ T010:都是 read-only gate run,可同時跑(實務上一個 terminal 連跑即可)。
+- T011、T012 必序列(quickstart 完才能算總時間)。
+
+### MVP Scope
+
+完成 Phase 1 + Phase 2 + Phase 3(US1)即達 MVP:
+
+- `/echo?msg=X` 回 200 + 正確 body
+- 基本 happy path 兌現,可 demo
+
+US2-US3 為快速漸進交付。Phase 6 收尾兌現 SC-005 + 001 baseline SC-007 計時。
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# US1 RED phase:
+Task: "Add 'GET /echo - happy path' describe block to tests/node/echo.test.ts (T003)"
+
+# 確認 RED:
+pnpm test  # 預期 echo.test.ts 失敗,其他 7 file 仍 pass
+
+# US1 GREEN phase:
+Task: "Add app.get('/echo', handler) to src/node/app.ts (T004)"
+
+# 確認 GREEN:
+pnpm test  # 預期 echo happy tests pass,total tests = 20 + N
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Phase 1 Setup(T001)
+2. Phase 2 Foundational(T002)
+3. Phase 3 US1(T003 → T004)
+4. **Stop & Validate**:`make up` + `curl /echo?msg=hello`,確認 200 + 正確 body
+
+### Incremental Delivery
+
+1. MVP(US1)→ baseline echo 可用
+2. US2(T005 → T006)→ 400 error 兌現
+3. US3(T007 → T008)→ metrics 繼承確認
+4. Polish(T009-T012)→ gates 再驗 + quickstart manual + 計時
+
+### 預期時間配置(SC-007 ≤ 1 hour)
+
+- Phase 1 + 2:5 min
+- US1(T003 + T004):15 min
+- US2(T005 + T006):10 min
+- US3(T007 + T008):10 min
+- Polish(T009-T012):15 min,含 quickstart manual walk-through
+
+合計 ≈ 55 min,在 SC-007 budget 內。
+
+---
+
+## Notes
+
+- [P] = 不同 logical task,可獨立思考(實際同檔 commit 仍須序列)
+- [Story] = 對應 spec.md user story(US1 / US2 / US3)
+- 每個 user story 完成後,quickstart.md 對應 step 應仍可跑通
+- 所有改動須通過容器內 / host 內 mandatory gates(test / typecheck / lint / prettier)
+- Commit / push 由 user 明確指示後執行(專案 CLAUDE.md 規範);本 plan 不自動 commit
+- T004 與 T006 共享同檔(`src/node/app.ts`)同函式,實作時請於 T004 一次寫完 happy + error 邏輯;T006 為「驗證 + 微調」性質而非「新增程式碼」
+- Sample feature 之後可丟可留:per spec.md preamble,SC-007 量化證據已落地於 `.docs/onboarding-stopwatch.md` 即達成 T009,feature 本身存廢屬 maintainer 決定

--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -21,6 +21,16 @@ if (process.env.HTTP_METRICS_ENABLED?.trim().toLowerCase() !== 'false') {
 
 app.get('/', (c) => c.json({ message: 'hello from hono' }));
 
+app.get('/echo', (c) => {
+  // SC-007 walkthrough sample (specs/001-superspec-baseline-T009/).
+  // Hono `c.req.query('msg')` returns the first value when repeated, and
+  // `undefined` when the key is absent. Empty-string and absent are both
+  // treated as missing, per spec.md Assumption 2.
+  const msg = c.req.query('msg');
+  if (!msg) return c.json({ error: 'missing msg' }, 400);
+  return c.json({ message: msg });
+});
+
 app.get('/health', async (c) => {
   const dbOk = await pool
     .query('SELECT 1')

--- a/tests/node/echo.test.ts
+++ b/tests/node/echo.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { app } from '../../src/node/app.ts';
+import { register } from '../../src/node/metrics.ts';
+
+describe('GET /echo - happy path (US1)', () => {
+  it('returns 200 + {message:"hello"} for ?msg=hello', async () => {
+    const res = await app.request('/echo?msg=hello');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    expect(await res.json()).toEqual({ message: 'hello' });
+  });
+
+  it('decodes URL-encoded space (?msg=hello%20world)', async () => {
+    const res = await app.request('/echo?msg=hello%20world');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: 'hello world' });
+  });
+
+  it('decodes URL-encoded UTF-8 (?msg=%E4%BD%A0%E5%A5%BD)', async () => {
+    const res = await app.request('/echo?msg=%E4%BD%A0%E5%A5%BD');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: '你好' });
+  });
+});
+
+describe('GET /echo - missing msg (US2)', () => {
+  it('returns 400 + {error:"missing msg"} for /echo with no query', async () => {
+    const res = await app.request('/echo');
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    expect(await res.json()).toEqual({ error: 'missing msg' });
+  });
+
+  it('returns 400 + {error:"missing msg"} for empty value (?msg=)', async () => {
+    const res = await app.request('/echo?msg=');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'missing msg' });
+  });
+
+  it('takes the first value when msg is repeated (?msg=a&msg=b)', async () => {
+    const res = await app.request('/echo?msg=a&msg=b');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: 'a' });
+  });
+});
+
+describe('GET /echo - metrics inheritance (US3)', () => {
+  // The shared `register` is process-global. Other test files (and the prior
+  // suites in this file) may have already populated `route="/echo"` samples.
+  // We snapshot before/after this suite's request and assert the counter
+  // increased — robust to any pre-existing samples without resetting state
+  // that other suites depend on.
+  let baseline: number;
+
+  beforeEach(async () => {
+    baseline = await readEchoSuccessCounter();
+  });
+
+  afterEach(() => {
+    // No reset — keep registry intact for downstream suites.
+  });
+
+  it('inherits per-route counter for /echo automatically (no explicit wiring)', async () => {
+    await app.request('/echo?msg=metrics-probe');
+    const after = await readEchoSuccessCounter();
+    expect(after).toBeGreaterThan(baseline);
+  });
+});
+
+/**
+ * Read the current value of `http_requests_total{method="GET", route="/echo",
+ * status_code="200"}` from the shared prom-client register. Returns 0 when no
+ * matching sample exists yet (e.g. fresh process before any /echo hit).
+ *
+ * Implemented via `register.metrics()` text scrape (rather than reaching into
+ * the Counter instance) to mirror the public observability surface used by
+ * Prometheus scrapers — what the production /metrics endpoint exposes is what
+ * we assert on.
+ */
+async function readEchoSuccessCounter(): Promise<number> {
+  const text = await register.metrics();
+  const line = text
+    .split('\n')
+    .find(
+      (l) =>
+        l.startsWith('http_requests_total{') &&
+        l.includes('method="GET"') &&
+        l.includes('route="/echo"') &&
+        l.includes('status_code="200"'),
+    );
+  if (!line) return 0;
+  const match = line.match(/\}\s+([0-9.]+)/);
+  return match ? Number(match[1]) : 0;
+}


### PR DESCRIPTION
## Summary

Lands the SC-007 walkthrough sample feature (Task T009 of 001-superspec-baseline). Adds a stateless `GET /echo` endpoint to the Node baseline application, fully driven through the spec-kit pipeline as a self-test of the baseline's "first feature ≤ 1 hour" promise.

## What's in this PR

- `src/node/app.ts` — +9 lines: `app.get('/echo', handler)` with `if (!msg) → 400` branch.
- `tests/node/echo.test.ts` — new file, 7 cases across 3 describe blocks (US1 happy × 3, US2 missing × 3, US3 metrics inheritance × 1).
- `specs/001-superspec-baseline-T009/` — full SDD pipeline outputs: spec, plan, research, data-model, contracts/echo.contract.md, quickstart, tasks, checklists.
- `.docs/onboarding-stopwatch.md` — "第一個 SDD feature 量測" section now records:
  ```
  /speckit-specify → /speckit-clarify (skipped) → /speckit-plan → /speckit-tasks → /speckit-implement
  Total: 21 min 5 sec (1265 s) — well below SC-007's ≤ 1 hour budget
  ```
- `CLAUDE.md` SPECKIT marker — points at the new T009 plan.md (parent baseline still discoverable via the "Background" section of the marker).

## Verification

- `pnpm test` — 8 file / 27 tests pass (original 20 + new 7)
- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0 (no-console rule verified on the new handler)
- `pnpm exec prettier --check .` — exit 0
- `make up` + manual `curl` walk-through of all 6 acceptance scenarios in `quickstart.md` — green:
  - happy: `?msg=hello` → `{"message":"hello"}`
  - URL-encoded space + 中文: decoded correctly
  - missing / empty `msg` → 400 + `{"error":"missing msg"}`
  - duplicate `?msg=a&msg=b` → first value wins
  - `/metrics` exposes `route="/echo"` counter + histogram (no explicit wiring — baseline observability invariant 1 holds)
- `make down` clean

## What this PR proves

**SC-007 of 001-superspec-baseline:** in-repo evidence that a first SDD feature on this monorepo can complete the full `/speckit-*` pipeline in ≪ 1 hour. Adopter reproducibility still each-on-their-own per the SC's own caveat, but the headroom (38m+) makes the budget very generous for typical trivial features.

**Baseline observability is real:** new route inherits per-route metrics + histogram with zero code added — concrete demonstration of FR-006 / SC-004 (and indirectly the "bonus" US3 in this feature's spec).

## Test plan

- [x] All mandatory gates exit 0 pre-merge
- [x] Manual quickstart walkthrough (6/6 acceptance scenarios)
- [x] `/metrics` confirms route="/echo" auto-inheritance
- [x] No console.* in the new handler (ESLint no-console)
- [ ] _Optional_: post-merge, decide whether to keep the feature as a permanent SC-007 anchor or remove it (per spec.md preamble; either is fine).

## Followups

- **002-cloudflare-worker** is now unblocked: 001 is fully merged with SC-007 evidence; activates FR-022 / SC-011 mechanical enforcement when it lands.
- **CI workflow** (FR-017 known gap of 001-baseline): still pending separate feature.
- **`experiment/mac-ssh-option5` branch**: kept on origin as historical evidence for issue #1 closure narrative; can be deleted whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)