### PR TITLE
docs(spec): P1 cleanup — close audit drift across constitution / spec / contracts / quickstart

### DIFF
--- a/.docs/onboarding-stopwatch.md
+++ b/.docs/onboarding-stopwatch.md
@@ -28,6 +28,22 @@
 
 ## 第一個 SDD feature 量測(T009 補充)
 
+> **⚠ Reverted-artifacts disclaimer**:本 T009 量測底下引用之 sample
+> feature artifacts(`specs/001-superspec-baseline-T009/`、
+> `tests/node/echo.test.ts`、`src/node/app.ts +9 lines`)於 main 上
+> **已被 revert**(commit `4c23544`)。
+>
+> **Scope 決策理由**:T009 之目的為量測 SDD pipeline 整輪 elapsed,以
+> in-repo 證據兌現 SC-007(adopter 第一個自家 feature 可於 ≤ 1 小時
+> 走完 specify → clarify → plan → tasks → implement);`/echo` sample
+> feature 為**量測載體**而非 baseline 出貨內容。將 sample feature 進
+> main 會牴觸 baseline「不預製範例 feature(由 adopter 自行決定首
+> feature)」之定位 → 故僅保留量測紀錄(本節)+ companion docs 進
+> main,sample feature 本體 revert。
+>
+> 引用之檔案路徑於 branch `001-superspec-baseline-T009` HEAD `c77ff12`
+> 上仍可驗證,作為 SC-007 之歷史 anchor;grep main 不會找到這些檔。
+
 **完成日期**:2026-04-30
 **Sample feature**:`GET /echo` endpoint(`specs/001-superspec-baseline-T009/`)
 **Branch**:`001-superspec-baseline-T009`(從 `001-superspec-baseline` HEAD `8b699c7` fork,以

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,7 +1,7 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: 1.0.0 → 1.1.0 (MINOR)
+Version change: 1.0.0 → 1.1.0 (MINOR) → 1.1.2 (PATCH)
 
 Amendment date: 2026-04-30 (same day as initial 1.0.0 ratification —
 v1.1.0 lands together with feature `002-cloudflare-worker`, which is
@@ -28,6 +28,8 @@ Modified principles in 1.0.0: N/A (initial ratification).
 Modified principles in 1.1.0: none (the five Core Principles are
   unchanged in body; the Variant Amendment is additive and clarifies
   scope, it does NOT redefine any principle).
+Modified principles in 1.1.2: none (PATCH-level wording refinement
+  only, see "Modified sections in 1.1.2" below).
 Added principles: I-V (full set, see Core Principles below).
 Added sections in 1.0.0: Technology Stack & Constraints, Development
   Workflow & Quality Gates, Governance, Reference Implementation Notes.
@@ -35,6 +37,21 @@ Added sections in 1.1.0: "Variant Amendment — Cloudflare Worker
   Companion (2026-04-30)" (declares the dual-runtime variant explicitly,
   per design source `.docs/20260430a-cloudflare-worker.md` §5.7 revised
   text + spec FR-016).
+Modified sections in 1.1.2 (PATCH, 2026-05-03 — wording-only refinement,
+  no principle change; triggered by post-merge code review on
+  001-superspec-baseline + 002-cloudflare-worker specs):
+  - Reference Implementation Notes (Source-control credential
+    forwarding bullet): removed `${localEnv:SSH_AUTH_SOCK}` mount
+    reference to align with post-issue-#1 `.devcontainer/devcontainer.json`
+    + `specs/001-superspec-baseline/contracts/sensitive-material.md`
+    (PR #4's `5bc629e` patched contracts but missed the constitution).
+  - Variant Amendment "Type Safety End-to-End strengthened":
+    "mechanical" → "partially mechanical" to match
+    `specs/002-cloudflare-worker/contracts/dual-tsconfig.md` §3.1 +
+    `.docs/baseline-traceability-matrix.md` FR-022 row. Full
+    mechanization (ESLint `no-restricted-imports` rule for explicit
+    named imports) tracked as separate follow-up; SC-011 enforcement
+    on ambient / builtin violations remains active from v1.1.0.
 Removed sections in any version since 1.0.0: none.
 
 Templates requiring updates (current status, manual follow-up):
@@ -505,7 +522,10 @@ accepting changes.
 - Linter / formatter configuration: `eslint.config.js`,
   `.prettierrc.json`, `.prettierignore`.
 - Source-control credential forwarding: SSH agent forwarded by the
-  dev container via `${localEnv:SSH_AUTH_SOCK}` mount.
+  dev container via VS Code Dev Containers' built-in mechanism — no
+  explicit `${localEnv:SSH_AUTH_SOCK}` mount; host `ssh-add` is the
+  prerequisite. Historical context (Mac launchd path hard-fail) lives
+  at `.docs/onboarding-stopwatch.md` Layer B caveat + issue #1.
 
 ## Variant Amendment — Cloudflare Worker Companion (2026-04-30)
 
@@ -545,14 +565,20 @@ encodes this divergence; this amendment names it explicitly so future
 contributors do not interpret principle III as a defect to be cleaned
 up by, e.g., containerizing the Worker.
 
-**Type Safety End-to-End strengthened — mechanical, not aspirational.**
+**Type Safety End-to-End strengthened — partially mechanical.**
 The dual `tsconfig.{node,worker}.json` structure supplies a
-**mechanical** cross-runtime import ban: a Node-only API imported from
-Worker code (or a Workers-only global from Node code) fails typecheck
-under the relevant tsconfig. The `pnpm typecheck` script chains both —
-exit 0 only when both runtimes' import boundaries are respected. This
-converts baseline forward-declaration FR-022 from aspirational to
-mechanical from this commit forward.
+**partially mechanical** cross-runtime import ban: ambient globals
+(`process`、`Buffer`)、`node:*` builtins、Workers-only globals
+(`D1Database`、`KVNamespace`)在錯誤的 tsconfig 下 typecheck **會失敗**;
+但**顯式 named import**(`import { Pool } from 'pg'`、
+`import type {} from '@cloudflare/workers-types'`)目前**僅 advisory**
+(per `specs/002-cloudflare-worker/contracts/dual-tsconfig.md` §3.1 +
+`.docs/baseline-traceability-matrix.md` FR-022 row)。`pnpm typecheck`
+chains both — 兩個 tsconfig 之 ambient / builtin 邊界皆 pass 才 exit 0。
+完全機械化下一步為 ESLint `no-restricted-imports` rule(已知 follow-up,
+非本 commit 範圍)。This converts baseline forward-declaration FR-022 from
+fully aspirational to partially mechanical from this commit forward;
+SC-011 violation count 從本 commit 起對 ambient / builtin 違規生效。
 
 **Test-First continues — dual pool.** Vitest runs two pools (Node side
 plain, Worker side miniflare via `@cloudflare/vitest-pool-workers`).
@@ -576,4 +602,4 @@ forward-declarations from `001-superspec-baseline`
 commit forward. Principles inherited unchanged: TDD, frequent commits,
 no over-engineering.
 
-**Version**: 1.1.0 | **Ratified**: 2026-04-30 | **Last Amended**: 2026-04-30
+**Version**: 1.1.2 | **Ratified**: 2026-04-30 | **Last Amended**: 2026-05-03

--- a/specs/001-superspec-baseline/spec.md
+++ b/specs/001-superspec-baseline/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `001-superspec-baseline`
 **Created**: 2026-04-30
-**Status**: Draft
+**Status**: Active
 **Input**: User description: "把現有 Node baseline + monorepo 結構規格化為 fresh spec"
 
 ## Clarifications

--- a/specs/002-cloudflare-worker/contracts/reverse-proxy.md
+++ b/specs/002-cloudflare-worker/contracts/reverse-proxy.md
@@ -84,6 +84,16 @@ const fetchInit = { method, headers, body: isBodyless ? undefined : raw.body };
 1. **路徑 1:1 對應**:Worker `/app-api/X` 之 X 與 Node `/app-api/X` 之 X 必完全相同(byte-for-byte)
 2. **錯誤 model 之 worker 自產 vs upstream 透傳分流清楚**:client 可從 `error` code 字面看出來源(`upstream_*` 三條為 worker;`pg_*`/`redis_*`/`not_found`/`missing_param` 為 Node 端產)
 3. **Headers 不主動改**:Worker passthrough 不改 `Authorization` / `Cookie` / `User-Agent` 等;adopter 若要加 worker token 須擴充本 contract
+
+   **Advisory(starter limitation)**:本 starter 為簡化起見,**未** strip
+   RFC 7230 §6.1 hop-by-hop headers(`Connection`、`Keep-Alive`、
+   `Transfer-Encoding`、`TE`、`Trailer`、`Proxy-Authorization`、
+   `Proxy-Authenticate`、`Upgrade`)。Cloudflare Workers runtime 對部分項
+   自身會 normalize(如 `Connection`、`Transfer-Encoding`),但 adopter
+   若 fork 至 production reverse proxy,**MUST** 自行依 RFC 7230 §6.1
+   review 並於 `proxy.ts` request 與 response 兩側補 hop-by-hop strip。
+   §1 不變量 4 描述者為 starter 行為,**不**等同 production-grade reverse
+   proxy 規範。
 4. **Streaming-friendly**:non-bodyless method 之 body 用 `c.req.raw.body`(`ReadableStream`),不 `await text()` 也不 buffer
 5. **Worker 端 timeout 為 10s固定**:不可調(per 設計源 §1.5 / §2);adopter 若需動態 timeout 屬擴充
 6. **`UPSTREAM_URL` MUST be an origin**:格式 `scheme://host[:port]`(如 `http://localhost:8000` / `https://api.example.com`)。**不支援** path 段(如 `https://example.com/api/`)— `proxy.ts:14` 對 trailing slash 做 `replace(/\/$/, '')` 是 defensive normalize,不是 base-path 支援。若 adopter 設定含 path 之 UPSTREAM_URL,實際發出之 target URL 行為**未定義**(可能誤拼為 `https://example.com/api/app-api/X`,但 contract 不保證)。base-path 路由屬 derivative 擴充。

--- a/specs/002-cloudflare-worker/quickstart.md
+++ b/specs/002-cloudflare-worker/quickstart.md
@@ -71,10 +71,23 @@ pnpm install --frozen-lockfile
 
 # 2. 確保 .dev.vars 設定為 mode B
 cp .dev.vars.example .dev.vars
-# 編輯 .dev.vars,把 UPSTREAM_URL 設為 http://host.docker.internal:8000
 #
-# (Linux 自架 Docker Engine 之 dev container 需 .devcontainer/devcontainer.json
-#  runArgs 加 --add-host=host.docker.internal:host-gateway,per plan key decision 7)
+# 編輯 .dev.vars 之 UPSTREAM_URL —— 取決於 wrangler dev 跑在哪裡:
+#
+# (a) wrangler dev 跑於 dev container 內(本 quickstart 預設情境):
+#     UPSTREAM_URL=http://host.docker.internal:8000
+#     - macOS / Windows Docker Desktop:host.docker.internal 自動可達
+#     - Linux 自架 Docker Engine:.devcontainer/devcontainer.json runArgs
+#       需加 --add-host=host.docker.internal:host-gateway
+#       (per plan key decision 7)
+#
+# (b) wrangler dev 跑於 host shell(非 dev container 內):
+#     UPSTREAM_URL=http://localhost:8000
+#     - 走 docker compose 在 host 之 published port (8000)
+#     - 不需 host.docker.internal 解析(host 本機 loopback 即可)
+#
+# 本 quickstart 之後續 step 假設 wrangler dev 與 docker compose 同視角
+# (均在容器內或均在 host);若混搭,請依 (b) 設 UPSTREAM_URL。
 
 # 3. 起 Node 端 docker compose stack(含 Postgres + Redis)
 make up


### PR DESCRIPTION
## Summary

P1 docs-only follow-up landing 5 zero-risk audit-drift fixes identified by `superpowers:code-reviewer` parallel pass on **001-superspec-baseline** + **002-cloudflare-worker** specs (post-merge review against `specs/<NNN>/spec.md`).

- **Constitution v1.1.0 → v1.1.2 (PATCH)** — drop stale `${localEnv:SSH_AUTH_SOCK}` reference (closes issue-#1 follow-up gap left by `5bc629e`); tighten Variant Amendment "mechanical" → "partially mechanical" to match `contracts/dual-tsconfig.md` §3.1 + traceability matrix.
- **001 spec status:** `Draft` → `Active` (post-merge ratification per `/speckit-analyze` report D1).
- **T009 stopwatch disclaimer:** make reverted-artifacts (commit `4c23544`) explicit + spell out the scope-decision rationale (baseline "no pre-bundled sample feature" stance).
- **002 quickstart Mode B:** replace single-path `UPSTREAM_URL` instruction with `(a) wrangler-in-container` vs `(b) wrangler-on-host` decision tree — closes Linux/host networking ambiguity.
- **Reverse-proxy contract §5 invariant 3:** add advisory block on RFC 7230 §6.1 hop-by-hop headers (starter limitation; production fork MUST strip).

Zero code / test / toolchain change. All 5 modifications are documentation.

## Files changed

| File | What |
| --- | --- |
| `.specify/memory/constitution.md` | v1.1.2 bump + 2 wording fixes + sync impact report PATCH block |
| `specs/001-superspec-baseline/spec.md` | L5 Status field |
| `.docs/onboarding-stopwatch.md` | T009 disclaimer + scope rationale |
| `specs/002-cloudflare-worker/quickstart.md` | Mode B step 2 decision tree |
| `specs/002-cloudflare-worker/contracts/reverse-proxy.md` | §5 invariant 3 hop-by-hop advisory |

## Test plan

- [x] `pnpm exec prettier --check .` — All matched files use Prettier code style ✓
- [x] `pnpm typecheck` — exit 0 (dual tsconfig chain pass) ✓
- [x] `pnpm lint` — exit 0 ✓
- [ ] CI green on `main` after merge
- [ ] No regression in `pnpm test:node` / `pnpm test:worker` (docs-only change; tests untouched)

## Out of scope (tracked separately)

Identified by reviewer but **NOT** in this PR — each warrants its own follow-up issue:

- **P2:** Add ESLint `no-restricted-imports` rule to fully mechanize FR-022 cross-runtime import ban (would let constitution drop "partially" qualifier).
- **P3 measured-evidence:** Run T038 Mac M1 + WSL2 worker-pool parity + T040 Mode C real deploy → record into `.docs/parity-validation.md` + stopwatch (upgrade SC-002 / SC-005 from documented to measured).
- **P4 independent issues:** `src/node/http-metrics.ts` inline FR-tag drift (refers to sibling-repo FR numbers); `tests/node/health.test.ts` filename vs. content mismatch (no real `/health` test); `package.json` `build` script vs `tsconfig.json` `noEmit: true` latent prod-deploy gap.

Generated alongside `superpowers:requesting-code-review` workflow run on `main` `64336a5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)