### PR TITLE
fix(p4): close 3 reviewer-flagged latent issues — FR-tag drift / test filename mismatch / build noEmit

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "node --watch --experimental-strip-types --disable-warning=ExperimentalWarning src/node/index.ts",
     "dev:node": "node --watch --experimental-strip-types --disable-warning=ExperimentalWarning src/node/index.ts",
     "dev:worker": "wrangler dev --config wrangler.jsonc",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/node/index.js",
     "test": "pnpm test:node && pnpm test:worker",
     "test:node": "vitest run --config vitest.config.node.ts",

--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -7,13 +7,13 @@ import { logger } from './logger.ts';
 
 export const app = new Hono();
 
-// FR-007: opt-out gate. Read once at module load (Edge Cases note: changes
-// do not hot-reload — restart required). Semantics:
+// Opt-out gate (per contracts/observability.md §1.3 invariant 5). Read once
+// at module load (changes do not hot-reload — restart required). Semantics:
 //   undefined / ''                → enabled (fail-open observability)
 //   'false' (case-insensitive, whitespace-trimmed) → disabled
 //   any other value ('TRUE', '1') → enabled
 // The `.trim()` defends against copy-pasted .env lines with trailing spaces
-// or newlines (see review-20260425-wsl.md M-2 regression tests).
+// or newlines.
 if (process.env.HTTP_METRICS_ENABLED?.trim().toLowerCase() !== 'false') {
   const METRICS_MOUNT = '/*';
   app.use(METRICS_MOUNT, httpMetrics({ mountPattern: METRICS_MOUNT }));

--- a/src/node/http-metrics.ts
+++ b/src/node/http-metrics.ts
@@ -7,37 +7,41 @@ import { logger } from './logger.ts';
  * Factory producing a Hono middleware that records two HTTP business metrics
  * (counter + duration histogram) against the shared prom-client `register`.
  *
- * Design notes (see specs/000-http-middleware-metrics/research.md):
- * - R6: metric objects are instantiated inside the factory body (NOT at module
- *   load) so that when `httpMetrics()` is never called (opt-out path in US2),
- *   no `http_*` metrics are registered and the `/metrics` scrape stays clean.
- * - R4: histogram buckets are left unspecified so prom-client's documented
- *   default `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]` applies.
- * - R5: requests to `/metrics` short-circuit — scrape traffic must not pollute
+ * Design notes (per specs/001-superspec-baseline/contracts/observability.md §1):
+ * - Metric objects are instantiated inside the factory body (NOT at module
+ *   load) so that when `httpMetrics()` is never called (opt-out path), no
+ *   `http_*` metrics are registered and the `/metrics` scrape stays clean.
+ * - Histogram buckets are left unspecified so prom-client's documented default
+ *   `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]` applies.
+ * - Requests to `/metrics` short-circuit — scrape traffic must not pollute
  *   business metrics.
- * - R7: no timers; updates are strictly request-driven.
+ * - No timers; updates are strictly request-driven.
  */
 
 export interface HttpMetricsOptions {
   /**
    * The Hono mount pattern at which this middleware is attached (e.g. '/*',
    * '/api/*'). Used to distinguish "no terminal handler matched" from
-   * "matched handler returned 404" for FR-005 (c). Caller must pass the SAME
-   * literal they pass to `app.use(...)` — the middleware has no runtime
-   * reflection into its own mount pattern. Defaults to '/*'.
+   * "matched handler returned 404" (per
+   * specs/001-superspec-baseline/contracts/observability.md §1.3 invariant 4).
+   * Caller must pass the SAME literal they pass to `app.use(...)` — the
+   * middleware has no runtime reflection into its own mount pattern.
+   * Defaults to '/*'.
    */
   mountPattern?: string;
 }
 
-// Module-local gate so the FR-014 degraded-label warning logs at most once
-// per process lifetime. Set by either the startup probe (`probeRoutePathSupport`)
+// Module-local gate so the degraded-label warning logs at most once per
+// process lifetime. Set by either the startup probe (`probeRoutePathSupport`)
 // or the per-request fallback inside the middleware — whichever detects the
 // degraded state first.
 let routePathUnavailableWarned = false;
 
 /**
- * FR-014 startup probe. Fires a synthetic request through a fresh Hono instance
- * and inspects `c.req.routePath` to detect whether the installed Hono version
+ * Startup probe (per
+ * specs/001-superspec-baseline/contracts/observability.md §1.3 invariant 3 +
+ * §1.4 row 3). Fires a synthetic request through a fresh Hono instance and
+ * inspects `c.req.routePath` to detect whether the installed Hono version
  * exposes the templated-route API. If absent (e.g. a future breaking change
  * removes the `@deprecated` getter without providing a drop-in replacement),
  * emit a single startup warning so adopters aren't silently degraded to
@@ -171,7 +175,8 @@ export const httpMetrics = (opts?: HttpMetricsOptions) => {
       const rawRoutePath = c.req.routePath;
       let route: string;
       if (rawRoutePath === '' || rawRoutePath == null) {
-        // FR-005 (b) + FR-014: Hono API degraded; warn once, bucket as 'unknown'.
+        // Hono API degraded (no routePath available); warn once, bucket as
+        // 'unknown' (per observability.md §1.3 invariant 3).
         if (!routePathUnavailableWarned) {
           routePathUnavailableWarned = true;
           logger.warn(
@@ -180,15 +185,17 @@ export const httpMetrics = (opts?: HttpMetricsOptions) => {
         }
         route = 'unknown';
       } else if (rawRoutePath === mountPattern && c.res.status === 404) {
-        // FR-005 (c): "未匹配任何 route(導致 404)". Both signals must align —
-        // rawRoutePath falling back to the middleware's own mount pattern AND
-        // status 404. This preserves FR-005 (a) for the legitimate case of a
+        // Unmatched 404 (per observability.md §1.3 invariant 4): "未匹配任何
+        // route(導致 404)". Both signals must align — rawRoutePath falling
+        // back to the middleware's own mount pattern AND status 404. This
+        // preserves the matched-route label for the legitimate case of a
         // matched handler returning 404 (e.g. REST "item not found" pattern
         // `app.get('/items/:id', c => c.json(..., 404))` — that request keeps
         // its templated route label, not 'not_found').
         route = 'not_found';
       } else {
-        // FR-005 (a): templated route path (e.g. "/", "/health", "/users/:id").
+        // Templated route path (e.g. "/", "/health", "/users/:id") — per
+        // observability.md §1.3 invariant 1 + 2 (auto-inherit + cardinality).
         route = rawRoutePath;
       }
 

--- a/tests/node/health.test.ts
+++ b/tests/node/health.test.ts
@@ -1,10 +1,56 @@
-import { describe, it, expect } from 'vitest';
-import { app } from '../../src/node/app.ts';
+import { describe, it, expect, vi } from 'vitest';
 
-describe('GET /', () => {
-  it('responds with hello message', async () => {
-    const res = await app.request('/');
+vi.mock('../../src/node/db.ts', () => ({
+  pool: { query: vi.fn() },
+}));
+vi.mock('../../src/node/redis.ts', () => ({
+  redis: { ping: vi.fn(), get: vi.fn() },
+}));
+
+const { app } = await import('../../src/node/app.ts');
+
+describe('GET /health', () => {
+  it('returns 200 + { status: ok, db: true, redis: true } when both backends respond', async () => {
+    const { pool } = await import('../../src/node/db.ts');
+    const { redis } = await import('../../src/node/redis.ts');
+    vi.mocked(pool).query.mockResolvedValue({ rows: [{ '?column?': 1 }] } as never);
+    vi.mocked(redis).ping.mockResolvedValue('PONG');
+
+    const res = await app.request('/health');
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ message: 'hello from hono' });
+    expect(await res.json()).toEqual({ status: 'ok', db: true, redis: true });
+  });
+
+  it('returns 503 + degraded shape when pool.query rejects (db down)', async () => {
+    const { pool } = await import('../../src/node/db.ts');
+    const { redis } = await import('../../src/node/redis.ts');
+    vi.mocked(pool).query.mockRejectedValue(new Error('pg ECONNREFUSED'));
+    vi.mocked(redis).ping.mockResolvedValue('PONG');
+
+    const res = await app.request('/health');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ status: 'degraded', db: false, redis: true });
+  });
+
+  it('returns 503 + degraded shape when redis.ping rejects (redis down)', async () => {
+    const { pool } = await import('../../src/node/db.ts');
+    const { redis } = await import('../../src/node/redis.ts');
+    vi.mocked(pool).query.mockResolvedValue({ rows: [{ '?column?': 1 }] } as never);
+    vi.mocked(redis).ping.mockRejectedValue(new Error('redis ETIMEDOUT'));
+
+    const res = await app.request('/health');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ status: 'degraded', db: true, redis: false });
+  });
+
+  it('returns 503 + both-false shape when both backends fail', async () => {
+    const { pool } = await import('../../src/node/db.ts');
+    const { redis } = await import('../../src/node/redis.ts');
+    vi.mocked(pool).query.mockRejectedValue(new Error('pg down'));
+    vi.mocked(redis).ping.mockRejectedValue(new Error('redis down'));
+
+    const res = await app.request('/health');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ status: 'degraded', db: false, redis: false });
   });
 });

--- a/tests/node/root.test.ts
+++ b/tests/node/root.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { app } from '../../src/node/app.ts';
+
+describe('GET /', () => {
+  it('responds with hello message', async () => {
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: 'hello from hono' });
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "rewriteRelativeImportExtensions": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/node/**/*", "src/shared/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.bench.ts", "tests/**", "dist/**"]
+}


### PR DESCRIPTION
## Summary

P4 follow-up — closes the three independent code-level debts the `superpowers:code-reviewer` pass left in PR #7's **"Out of scope"** list. Each issue is independently fixable; bundled here because they're all surgical and benefit from a single CI run.

**Stacked on PR #9** (`docs/p3-measured-evidence`). Will retarget to `main` after PR #7 → #8 → #9 → #10 chain merges.

## Three issues addressed

### Issue 1 — `src/node/http-metrics.ts` + `app.ts` FR-tag drift

Inline comments cited FR numbers from the **nodejs-sibling repo's** `000-http-middleware-metrics/spec.md` (which doesn't exist here). In this repo's spec, FR-005 = TDD discipline and FR-014 = SSH agent forwarding — neither relates to `routePath` / 404 handling.

Fix: replace 5 sites with this-repo's `contracts/observability.md §1.3` invariant anchors (more durable across spec amendments per reviewer's preferred option b). Also dropped:
- `(see specs/000-http-middleware-metrics/research.md)` dangling reference
- R6/R4/R5/R7 sibling-repo mnemonic codes (no source doc to look them up)
- `app.ts:16 review-20260425-wsl.md M-2` non-existent file reference

### Issue 2 — `tests/node/health.test.ts` filename vs content mismatch

The file's `describe('GET /')` block tested `/`, not `/health` — misleading filename and SC-010 evidence gap.

Fix:
- `git mv tests/node/health.test.ts → tests/node/root.test.ts` (rename matches actual content, no logic change)
- **NEW** `tests/node/health.test.ts`: 4 proper `/health` tests covering all 4 status branches (200 happy / 503 db-down / 503 redis-down / 503 both-down). Uses `vi.mock(pool/redis)` pattern from `app-api.test.ts`. Closes SC-010 status-differentiation evidence gap (previously only shape-tested in `http-metrics.opt-out.test.ts`).

### Issue 3 — `pnpm build` was noEmit (Dockerfile prod stage was broken)

`tsconfig.json:9 noEmit: true` + `package.json:13 "build": "tsc -p tsconfig.json"` meant `pnpm build` produced no output. Dockerfile's `COPY --from=build /app/dist ./dist` copied nothing; runtime stage's `CMD ["node", "dist/node/index.js"]` would fail at startup (latent bug, no current path uses prod image yet).

Fix: dedicated `tsconfig.build.json` (per reviewer's preferred option b):
- extends `tsconfig.node.json`
- overrides: `noEmit: false`, `outDir: ./dist`, `rootDir: ./src`, `rewriteRelativeImportExtensions: true` (TS 5.7+ flag — auto-rewrites `.ts` import extensions to `.js`), `sourceMap: true`
- excludes `tests/**` and `*.bench.ts`
- `package.json:13` → `tsc -p tsconfig.build.json`

**Verified emit:** `pnpm build` produces `dist/node/{index,app,db,redis,logger,metrics,http-metrics}.js` + `dist/shared/types.js` (8 .js + 8 .map). `.ts` imports correctly rewritten:

```
dist/node/index.js:import { app } from "./app.js";
dist/node/index.js:import { redis } from "./redis.js";
dist/node/index.js:import { logger } from "./logger.js";
dist/node/app.js:import { httpMetrics } from "./http-metrics.js";
```

Dockerfile `node dist/node/index.js` is now end-to-end functional. `dist/` already in `.gitignore` L38.

## Test plan

- [x] `pnpm exec prettier --check .` — All matched files use Prettier code style ✓
- [x] `pnpm typecheck` — exit 0 (dual tsconfig; `.build.json` is build-only, not in typecheck chain) ✓
- [x] `pnpm lint` — exit 0 (incl P2 `no-restricted-imports`) ✓
- [x] `pnpm test:node` — **9 files / 30 tests pass** (was 8/26: +1 file +4 tests from new `health.test.ts`; `root.test.ts` is the renamed original) ✓
- [x] `pnpm test:worker` — 5 files / 18 tests pass (unchanged; **total 14 files / 48 tests**) ✓
- [x] `pnpm build` — emits 16 files in `dist/` with correct `.js` extension rewriting; `.ts` imports gone (verified via grep, then cleaned) ✓
- [ ] `docker build --target=runtime .` — not run locally (heavy); CI or adopter run will fully validate the fix end-to-end. Build step now produces what Dockerfile expects.

## Files changed

| File | Status | What |
| --- | --- | --- |
| `src/node/http-metrics.ts` | M | Issue 1 — 5 FR-tag rewrites + drop sibling-repo mnemonic refs |
| `src/node/app.ts` | M | Issue 1 — drop `review-20260425-wsl.md M-2` dangling cite |
| `tests/node/health.test.ts` → `tests/node/root.test.ts` | R | Issue 2 — rename to match content (tests `/`) |
| `tests/node/health.test.ts` | + | Issue 2 — NEW: 4 tests for `/health` (200/503 differentiation) |
| `tsconfig.build.json` | + | Issue 3 — NEW: emit-mode tsconfig with `.ts` → `.js` rewrite |
| `package.json` | M | Issue 3 — `build` script points at new tsconfig |

## Out of scope (rolling)

After this PR, the original reviewer report is fully addressed. Remaining items beyond this 4-PR series are deferred for the user's discretion:

- Mac M1 hardware run (P3 placeholder still PENDING)
- Live `wrangler deploy` SC-005 wall-time (P3 placeholder still PENDING)
- Wrangler v3 → v4 upgrade (separate follow-up; v4 was released after 002 land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)