### PR TITLE
[negative test 3/T008] bundle bloat > 100 KiB → expect bundle-check fail

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+# Dependabot configuration — 003-ci-workflow T010
+#
+# Per spec.md FR-006 + FR-007 + contracts/dependabot-policy.md §2-3 +
+# research.md §5. Two ecosystems (npm + github-actions). Weekly Monday
+# scan. PR commits follow `chore(deps): bump xxx` convention (per 001
+# FR-019 toolchain isolated commit).
+#
+# Major bumps: NOT grouped (Dependabot 預設行為 → 各自獨立 PR);
+# minor + patch: grouped per ecosystem family to keep transitive deps
+# aligned (lesson from issue #15 wrangler/workerd dedupe drift).
+#
+# Spec: specs/003-ci-workflow/spec.md
+# Contract: specs/003-ci-workflow/contracts/dependabot-policy.md
+
+version: 2
+
+updates:
+  # ═══════════════════════════════════════════════════════════════════════
+  # npm ecosystem — package.json dependencies + devDependencies
+  # 4 grouping rules + major-as-separate-PR (Dependabot default)
+  # ═══════════════════════════════════════════════════════════════════════
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    target-branch: 'main'
+    commit-message:
+      prefix: 'chore(deps)'
+      include: 'scope'
+    groups:
+      # Cloudflare ecosystem: align workers-types / vitest-pool-workers /
+      # wrangler / future miniflare to same release cadence (issue #15
+      # root-cause: transitive workerd / wrangler dedupe drift)
+      cloudflare-ecosystem:
+        patterns:
+          - '@cloudflare/*'
+          - 'wrangler'
+          - 'miniflare'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # TypeScript ESLint: parser + plugins + rules must align
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'typescript-eslint'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # Vitest: core + runner + spy + workers pool plugin must align
+      vitest:
+        patterns:
+          - '@vitest/*'
+          - 'vitest'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # All other deps' minor + patch in one group to reduce PR noise
+      node-deps-minor-patch:
+        patterns:
+          - '*'
+        exclude-patterns:
+          - '@cloudflare/*'
+          - 'wrangler'
+          - 'miniflare'
+          - '@typescript-eslint/*'
+          - 'typescript-eslint'
+          - '@vitest/*'
+          - 'vitest'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # GitHub Actions ecosystem — .github/workflows/*.yml action versions
+  # Monitors actions/checkout / pnpm/action-setup / actions/cache /
+  # actions/github-script / devcontainers/ci / gitleaks/gitleaks-action
+  # (per research §13 工具鏈 anchor 一覽)
+  # ═══════════════════════════════════════════════════════════════════════
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 3
+    target-branch: 'main'
+    commit-message:
+      prefix: 'chore(deps)'
+      include: 'scope'
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,3 +210,151 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 預設行為:PR mode 掃 PR diff;non-PR (push) 掃 git log
           # gitleaks 預設 redact secret value (only file + line shown);per FR-011
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # spec-coverage-advisory — comment when PR touches src/** but no
+  # specs/NNN-*/ artifact updated (T013 / per FR-008 第 1 條 +
+  # ci-gates.md §5 + research §6, §11)
+  # Status: ADVISORY (never blocks merge); NOT in branch protection list
+  # Mechanizes 001 SC-003 advisory提示 (reviewer 仍保留豁免權)
+  # ═══════════════════════════════════════════════════════════════════════
+  spec-coverage-advisory:
+    name: spec-coverage-advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write # 須能 post comment
+      contents: read
+    steps:
+      - name: Check spec coverage + post advisory if needed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            // FR-009: skip 完全 doc-only PR (動 specs/** + .docs/** + *.md only)
+            const isDocFile = (f) =>
+              f.startsWith('specs/') ||
+              f.startsWith('.docs/') ||
+              f.endsWith('.md');
+            const isDocOnly = files.every((f) => isDocFile(f.filename));
+            if (isDocOnly) {
+              core.info('Doc-only PR — skip spec-coverage-advisory (per FR-009)');
+              return;
+            }
+
+            // Trigger condition: PR touches src/** but does NOT touch specs/NNN-*/
+            const touchesSrc = files.some((f) => f.filename.startsWith('src/'));
+            const touchesSpecs = files.some((f) => f.filename.startsWith('specs/'));
+
+            if (touchesSrc && !touchesSpecs) {
+              const body = [
+                '⚠ **Advisory: spec coverage**',
+                '',
+                'This PR modifies `src/**` but no `specs/NNN-*/` artifact was added or updated.',
+                '',
+                'Per 001 baseline FR-004 (spec-kit pipeline) + SC-003, non-trivial changes',
+                'should correspond to a spec directory. Reviewer please decide:',
+                '',
+                '- (a) This is a trivial change exempt from spec coverage (per FR-004 trivial 豁免)',
+                '  — leave a comment in this PR explaining the exemption rationale',
+                '- (b) Open a spec PR first, then update this PR to reference it',
+                '',
+                '_This advisory does NOT block merge. It re-fires on every push (per design)._',
+                '_Spec: `specs/003-ci-workflow/contracts/ci-gates.md` §5_',
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Posted spec-coverage-advisory comment');
+            } else {
+              core.info('PR has matching spec coverage OR does not touch src/ — no comment');
+            }
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # toolchain-isolation-advisory — comment when PR mixes deps + src changes
+  # (T015 / per FR-008 第 2 條 + ci-gates.md §6 + research §6, §11)
+  # Status: ADVISORY (never blocks merge); NOT in branch protection list
+  # Mechanizes 001 FR-019 advisory提示 (toolchain isolated commit nudge)
+  # ═══════════════════════════════════════════════════════════════════════
+  toolchain-isolation-advisory:
+    name: toolchain-isolation-advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Check toolchain isolation + post advisory if needed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            // FR-009: skip doc-only PR (same logic as spec-coverage-advisory;
+            // inline duplicate per plan §Constitution Check IV note "本 task
+            // 初版用 inline 重複,後續 follow-up 抽 composite action")
+            const isDocFile = (f) =>
+              f.startsWith('specs/') ||
+              f.startsWith('.docs/') ||
+              f.endsWith('.md');
+            const isDocOnly = files.every((f) => isDocFile(f.filename));
+            if (isDocOnly) {
+              core.info('Doc-only PR — skip toolchain-isolation-advisory (per FR-009)');
+              return;
+            }
+
+            // Trigger condition: PR touches BOTH (package.json or pnpm-lock.yaml)
+            // AND (src/** or tests/**)
+            const touchesDeps = files.some(
+              (f) => f.filename === 'package.json' || f.filename === 'pnpm-lock.yaml'
+            );
+            const touchesSrcOrTests = files.some(
+              (f) => f.filename.startsWith('src/') || f.filename.startsWith('tests/')
+            );
+
+            if (touchesDeps && touchesSrcOrTests) {
+              const body = [
+                '⚠ **Advisory: toolchain isolation**',
+                '',
+                'This PR modifies BOTH toolchain (`package.json` / `pnpm-lock.yaml`) AND',
+                'application code (`src/**` / `tests/**`).',
+                '',
+                'Per 001 baseline FR-019 + 002 spec assumption #6, toolchain bumps should',
+                'be isolated commits / PRs to enable single-commit revert. Reviewer please',
+                'decide:',
+                '',
+                '- (a) Split into two PRs (recommended)',
+                '- (b) Leave a comment in this PR explaining why bundling is necessary',
+                '  (e.g. dep upgrade requires src adaptation in same logical change)',
+                '',
+                '_This advisory does NOT block merge. It re-fires on every push (per design)._',
+                '_Spec: `specs/003-ci-workflow/contracts/ci-gates.md` §6_',
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Posted toolchain-isolation-advisory comment');
+            } else {
+              core.info('PR is toolchain-only OR src-only — no comment');
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,12 @@ jobs:
           imageName: ghcr.io/${{ github.repository }}/dev-container
           cacheFrom: ghcr.io/${{ github.repository }}/dev-container
           push: never # 不 push image to GHCR (avoids needing GITHUB_TOKEN write perm)
+          # devcontainers/ci@v0.3 不自動 propagate host env vars 進 container,
+          # 須顯式 export CI=true 讓 vitest sc007 之 describe.skipIf(process.env.CI === 'true')
+          # 在 CI runner 內生效 (per fix/sc007-ci-threshold PR #22 commit ec725df)
           runCmd: |
             set -euo pipefail
+            export CI=true
             pnpm install --frozen-lockfile
             pnpm typecheck
             pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,112 @@ jobs:
             pnpm lint
             pnpm test:node
             pnpm test:worker
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # wrangler-bundle-check — verify Worker bundle clean + size budget (T005 /
+  # per FR-003 第 2 條 + ci-gates.md §3 + research §4)
+  # Status: mandatory; branch protection 須加入 Required status checks 清單
+  # Mechanizes 002 FR-009 + SC-003 (bundle 不含 Node-only modules) +
+  # 003 SC-005 (bundle size ≤ 100 KiB).
+  # ═══════════════════════════════════════════════════════════════════════
+  wrangler-bundle-check:
+    name: wrangler-bundle-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15 # cache hit ≤ 3 min;cache miss ≤ 10 min;5 min margin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Pre-create devcontainer mount sources
+        run: |
+          mkdir -p ~/.claude
+          [ -f ~/.claude.json ] || echo '{}' > ~/.claude.json
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            node_modules-${{ runner.os }}-
+
+      # ───────────────────────────────────────────────────────────────────
+      # Inside dev container: wrangler dry-run + grep + size assertion
+      # (per research §4 + ci-gates.md §3.1)
+      # 7 forbidden modules: pg / redis / pino / prom-client /
+      # @hono/node-server / node:fs / node:child_process
+      # Bundle budget: 100 KiB (~64 KiB current, 50% headroom; per spec Q2 + SC-005)
+      # ───────────────────────────────────────────────────────────────────
+      - name: Run wrangler bundle check inside dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository }}/dev-container
+          cacheFrom: ghcr.io/${{ github.repository }}/dev-container
+          push: never
+          runCmd: |
+            set -euo pipefail
+            pnpm install --frozen-lockfile
+            pnpm exec wrangler deploy --dry-run
+
+            BUNDLE=.wrangler/dryrun/index.js
+            if [ ! -f "$BUNDLE" ]; then
+              echo "❌ Bundle not found at $BUNDLE — wrangler dry-run failed silently?"
+              ls -la .wrangler/ 2>&1 || echo "(.wrangler/ missing entirely)"
+              exit 1
+            fi
+
+            # Check 1: bundle 不含 Node-only modules (002 FR-009 / SC-003)
+            FORBIDDEN=("pg" "redis" "pino" "prom-client" "@hono/node-server" "node:fs" "node:child_process")
+            FAIL=0
+            for mod in "${FORBIDDEN[@]}"; do
+              if grep -q "$mod" "$BUNDLE"; then
+                echo "❌ BUNDLE CONTAINS FORBIDDEN MODULE: $mod"
+                grep -n "$mod" "$BUNDLE" | head -5
+                FAIL=1
+              fi
+            done
+            if [ "$FAIL" -ne 0 ]; then
+              exit 1
+            fi
+
+            # Check 2: bundle size ≤ 100 KiB (003 SC-005)
+            SIZE=$(wc -c < "$BUNDLE")
+            BUDGET=$((100 * 1024))
+            if [ "$SIZE" -gt "$BUDGET" ]; then
+              echo "❌ BUNDLE SIZE $SIZE bytes ($((SIZE / 1024)) KiB) exceeds budget $BUDGET bytes (100 KiB)"
+              exit 1
+            fi
+            echo "✅ bundle clean: $SIZE bytes ($((SIZE / 1024)) KiB), budget $((BUDGET / 1024)) KiB"
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # secret-scan — gitleaks scan PR diff or full git history (T006 / per
+  # FR-003 第 3 條 + ci-gates.md §4 + research §2)
+  # Status: mandatory; branch protection 須加入 Required status checks 清單
+  # Mechanizes 001 SC-006 (zero OAuth credentials in git history).
+  # NOT inside dev container (gitleaks-action is standalone — no need
+  # for Node / pnpm / wrangler).
+  # ═══════════════════════════════════════════════════════════════════════
+  secret-scan:
+    name: secret-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (full history for git log scan)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 全 history,讓 gitleaks 可掃 git log on push to main
+
+      - name: Run gitleaks (PR diff for PR; full history for push to main)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 預設行為:PR mode 掃 PR diff;non-PR (push) 掃 git log
+          # gitleaks 預設 redact secret value (only file + line shown);per FR-011

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# CI Workflow — 003-ci-workflow
+#
+# Mechanizes 001 baseline FR-017 (CI ↔ dev container same base image) +
+# SC-005 (toolchain revert) + SC-006 (zero OAuth in git) + 002 FR-009 /
+# SC-003 (Worker bundle 不含 Node-only modules).
+#
+# 3 mandatory + 2 advisory job. Mandatory failure 阻擋 merge (via branch
+# protection); advisory only PR comment, never blocks.
+#
+# Spec: specs/003-ci-workflow/spec.md
+# Plan: specs/003-ci-workflow/plan.md
+# Contracts: specs/003-ci-workflow/contracts/ci-gates.md
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs on the same ref (per research §7).
+# - Same PR push twice → only latest commit runs
+# - PR run + main run → independent (different ref)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Jobs added in subsequent tasks (T004 gates / T005 wrangler-bundle-check /
+  # T006 secret-scan / T013 spec-coverage-advisory / T015 toolchain-isolation-advisory).
+  # Skeleton placeholder (workflow YAML requires at least one job to be valid).
+  noop-skeleton:
+    runs-on: ubuntu-latest
+    if: false # Never runs; placeholder to keep YAML valid until T004+ add real jobs
+    steps:
+      - run: echo "skeleton placeholder"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
           runCmd: |
             set -euo pipefail
             pnpm install --frozen-lockfile
-            pnpm exec wrangler deploy --dry-run
+            # wrangler v4 之 `--dry-run` 不寫 bundle 至 disk (只算 + print stats);
+            # 加 `--outdir` 強制寫出 .wrangler/dryrun/index.js 供 grep + size assertion
+            pnpm exec wrangler deploy --dry-run --outdir .wrangler/dryrun
 
             BUNDLE=.wrangler/dryrun/index.js
             if [ ! -f "$BUNDLE" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,70 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Jobs added in subsequent tasks (T004 gates / T005 wrangler-bundle-check /
-  # T006 secret-scan / T013 spec-coverage-advisory / T015 toolchain-isolation-advisory).
-  # Skeleton placeholder (workflow YAML requires at least one job to be valid).
-  noop-skeleton:
+  # ═══════════════════════════════════════════════════════════════════════
+  # gates — 4 mandatory gates inside dev container (T004 / per FR-003 第 1 條 +
+  # FR-004 + ci-gates.md §2)
+  # Status: mandatory; branch protection 須加入 Required status checks 清單
+  # ═══════════════════════════════════════════════════════════════════════
+  gates:
+    name: gates
     runs-on: ubuntu-latest
-    if: false # Never runs; placeholder to keep YAML valid until T004+ add real jobs
+    timeout-minutes: 20 # SC-001 cache miss budget 15 min + 5 min safety margin
     steps:
-      - run: echo "skeleton placeholder"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ───────────────────────────────────────────────────────────────────
+      # Pre-create mount sources for devcontainer.json bind mounts.
+      # CI runner 無 ~/.claude (no Claude OAuth needed in CI), but
+      # devcontainer.json mounts ~/.claude + ~/.claude.json → docker run
+      # would fail at start without these paths existing on host.
+      # 此 step 純創 empty paths,不放 secret。
+      # (per T002 verification finding + research §1)
+      # ───────────────────────────────────────────────────────────────────
+      - name: Pre-create devcontainer mount sources
+        run: |
+          mkdir -p ~/.claude
+          [ -f ~/.claude.json ] || echo '{}' > ~/.claude.json
+
+      # ───────────────────────────────────────────────────────────────────
+      # Cache pnpm store (per research §3 + ci-gates.md §2.1 step 2)
+      # Key: lockfile hash + runner OS;restore-keys fallback for stale lockfile
+      # ───────────────────────────────────────────────────────────────────
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      # ───────────────────────────────────────────────────────────────────
+      # Cache node_modules (per research §3 + ci-gates.md §2.1 step 3)
+      # ───────────────────────────────────────────────────────────────────
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            node_modules-${{ runner.os }}-
+
+      # ───────────────────────────────────────────────────────────────────
+      # Run 4 mandatory gates inside dev container (per FR-004 + research §1)
+      # Uses devcontainers/ci@v0.3 (Microsoft official) which builds the
+      # .devcontainer/Dockerfile + applies features + runs runCmd inside.
+      # ───────────────────────────────────────────────────────────────────
+      - name: Run 4 mandatory gates inside dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository }}/dev-container
+          cacheFrom: ghcr.io/${{ github.repository }}/dev-container
+          push: never # 不 push image to GHCR (avoids needing GITHUB_TOKEN write perm)
+          runCmd: |
+            set -euo pipefail
+            pnpm install --frozen-lockfile
+            pnpm typecheck
+            pnpm lint
+            pnpm test:node
+            pnpm test:worker

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/002-cloudflare-worker"}
+{"feature_directory":"specs/003-ci-workflow"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,25 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/002-cloudflare-worker/plan.md` (Cloudflare Worker runtime +
-monorepo dual-runtime refactor;兌現 001-baseline forward-declarations).
+at `specs/003-ci-workflow/plan.md` (Ubuntu CI workflow + Dependabot —
+mechanize 001 FR-017 / SC-005 / SC-006 + 002 FR-009 / SC-003).
 Phase 1 design artifacts:
 
-- `specs/002-cloudflare-worker/spec.md` — 5 user stories / 17 FRs / 11 SCs / 15 edge cases / 1 clarification
-- `specs/002-cloudflare-worker/research.md` — Phase 0 (Q1 Clarification + 設計源 §6 decisions log + §2.3 7 lessons)
-- `specs/002-cloudflare-worker/data-model.md` — Phase 1 (Worker entry + Bindings + Dual tsconfig + Dual Vitest + Constitution amendment)
-- `specs/002-cloudflare-worker/contracts/` — Phase 1 (4 contracts:
-  worker-routes / reverse-proxy / bindings / dual-tsconfig)
-- `specs/002-cloudflare-worker/quickstart.md` — Phase 1 (Mode A quick / Mode B full / Mode C deploy walkthrough)
+- `specs/003-ci-workflow/spec.md` — 4 user stories / 13 FRs / 11 SCs / 10 edge cases / 6 clarifications
+- `specs/003-ci-workflow/research.md` — Phase 0 (14 design decisions:devcontainers/ci action / gitleaks-action / cache strategy / wrangler-bundle-check mechanism / Dependabot grouping / advisory comment via github-script / branch protection guidance)
+- `specs/003-ci-workflow/data-model.md` — Phase 1 (CI workflow entity 結構 + 5 jobs + Dependabot config + .gitleaks.toml + README §)
+- `specs/003-ci-workflow/contracts/` — Phase 1 (2 contracts:
+  ci-gates / dependabot-policy)
+- `specs/003-ci-workflow/quickstart.md` — Phase 1 (Adopter fork walkthrough + maintainer ops + reviewer 看 PR + 6 negative test scenarios)
 
 Background:
 
 - `specs/001-superspec-baseline/` — baseline spec / plan / contracts (merged to main, 5 contracts)
-- `.specify/memory/constitution.md` — project constitution v1.0.0
-  (Node + Worker dual-runtime principles;本 feature 落地時升 v1.1.0 加 Variant Amendment)
-- `.docs/20260430a-cloudflare-worker.md` — 設計源(working doc;本 feature 之 spec/plan 為其規格化產物)
+- `specs/002-cloudflare-worker/` — Worker runtime + dual-runtime monorepo refactor (merged to main, 4 contracts;PR #5/#13/#17/#18/#19/#20 後續清完 audit + SC-002 strict pair fully verified)
+- `.specify/memory/constitution.md` — project constitution v1.1.3
+  (Node + Worker dual-runtime principles + Variant Amendment + FR-022 fully mechanical)
+- `.docs/parity-validation.md` — SC-002 measurement records(WSL2 + Mac M1 strict-pair verified at vitest-pool-workers 0.15.2)
+- `.docs/baseline-traceability-matrix.md` — 001/002 之 FR/SC 機械化狀態總表
 <!-- SPECKIT END -->
 
 # Git Workflow (Project-Specific Override of Global Preferences)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,56 @@
 
 ---
 
+## CI status
+
+[![CI](https://github.com/anew7237/claude-superspec-worker/actions/workflows/ci.yml/badge.svg)](https://github.com/anew7237/claude-superspec-worker/actions/workflows/ci.yml)
+
+本 monorepo 內建 GitHub Actions CI workflow(`.github/workflows/ci.yml`)+ Dependabot 自動升版(`.github/dependabot.yml`)— **adopter fork 後自動啟用,不需在 GitHub UI 額外配置**(per `specs/003-ci-workflow/`)。
+
+### Jobs
+
+| Job                                | 性質         | 行為                                                                                                                                                                 |
+| ---------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`gates`**                        | mandatory ✅ | 在 dev container 內跑 `pnpm typecheck` / `pnpm lint` / `pnpm test:node` / `pnpm test:worker` 4 mandatory gates                                                       |
+| **`wrangler-bundle-check`**        | mandatory ✅ | `wrangler deploy --dry-run` + grep bundle 驗 0 個 Node-only module(pg/redis/pino/prom-client/@hono/node-server/node:fs/node:child_process)+ size assertion ≤ 100 KiB |
+| **`secret-scan`**                  | mandatory ✅ | gitleaks 掃 PR diff(PR 觸發)/ 全 git history(push to main 觸發);0 OAuth credentials in commits                                                                       |
+| **`spec-coverage-advisory`**       | advisory ⚠️  | PR 動 `src/**` 但無對應 `specs/NNN-*/` artifact → comment 提示(不阻擋 merge)                                                                                         |
+| **`toolchain-isolation-advisory`** | advisory ⚠️  | PR 同時動 `package.json` / `pnpm-lock.yaml` 與 `src/**` / `tests/**` → comment 提示「toolchain 變更建議獨立 PR」(不阻擋 merge)                                       |
+
+### 觸發條件
+
+- `pull_request` to main(任何 PR)
+- `push` to main(merge 後驗證)
+- `workflow_dispatch`(手動觸發備用)
+
+### Dependabot
+
+每週一掃 npm + GitHub Actions 升版;按 grouping rule 開 PR(`@cloudflare/*` 同組;`@vitest/*` 同組;`@typescript-eslint/*` 同組;其他 minor + patch 一組;major 各自獨立 PR)。Open PR limit:npm 5 / github-actions 3。
+
+### Branch protection 設定(adopter fork 後手動設,1 分鐘)
+
+CI workflow 跑出來後,Required status checks 才可被加入 branch protection 清單。至 `Settings → Branches → Add branch protection rule for main`:
+
+1. ✅ **Require a pull request before merging**
+2. ✅ **Require status checks to pass before merging**
+3. 在 `Required status checks` 搜尋並加入 **3 個 mandatory checks**:
+   - ✅ `gates`
+   - ✅ `wrangler-bundle-check`
+   - ✅ `secret-scan`
+4. ❌ **不要加** advisory checks(`spec-coverage-advisory`、`toolchain-isolation-advisory`)— 它們是提示,加進來會誤擋 PR
+5. (可選)✅ **Require branches to be up to date before merging**
+
+完成後任何 PR 須 3 mandatory check 全綠才可 merge。
+
+### 詳細文件
+
+- 完整 walkthrough(adopter / maintainer / reviewer × 7 sections + 6 negative test scenarios):[`specs/003-ci-workflow/quickstart.md`](specs/003-ci-workflow/quickstart.md)
+- Spec(13 FRs / 11 SCs / 4 user stories):[`specs/003-ci-workflow/spec.md`](specs/003-ci-workflow/spec.md)
+- 5 jobs 之契約(input / output / failure mode):[`specs/003-ci-workflow/contracts/ci-gates.md`](specs/003-ci-workflow/contracts/ci-gates.md)
+- Dependabot policy 契約:[`specs/003-ci-workflow/contracts/dependabot-policy.md`](specs/003-ci-workflow/contracts/dependabot-policy.md)
+
+---
+
 ## Baseline Spec & Contracts
 
 本專案最新一版 baseline spec 位於 `specs/001-superspec-baseline/`,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0",
+    "lodash": "^4.18.1",
     "pg": "^8.13.0",
     "pino": "^9.5.0",
     "prom-client": "^15.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       hono:
         specifier: ^4.6.0
         version: 4.12.14
+      lodash:
+        specifier: ^4.18.1
+        version: 4.18.1
       pg:
         specifier: ^8.13.0
         version: 8.20.0
@@ -1282,6 +1285,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2737,6 +2743,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.18.1: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/specs/003-ci-workflow/checklists/requirements.md
+++ b/specs/003-ci-workflow/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Specification Quality Checklist: CI Workflow + Dependabot — Ubuntu Mechanization of Baseline Gates
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+  - Note: Spec mentions concrete tools (gitleaks, Dependabot, GitHub Actions, wrangler, pnpm) consistent with project convention (002 spec mentions Hono, Postgres, miniflare). These are contractual choices, not implementation hiding.
+- [x] Focused on user value and business needs
+  - 4 user stories prioritized P1-P3 cover newcomer / maintainer / fork / reviewer journeys
+- [x] Written for non-technical stakeholders
+  - User stories use natural language; technical details deferred to FR section
+- [x] All mandatory sections completed
+  - User Scenarios & Testing ✓ / Requirements ✓ / Success Criteria ✓ / Assumptions ✓ / Dependencies ✓
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+  - All 6 design knobs answered upfront in Clarifications §
+- [x] Requirements are testable and unambiguous
+  - 13 FRs each have clear pass/fail conditions; bundle threshold (100 KiB) + ≤ 10 min cache hit + ≤ 15 min cache miss are concrete
+- [x] Success criteria are measurable
+  - 11 SCs all include quantitative or binary metrics (% / time / count / boolean pass-fail)
+- [x] Success criteria are technology-agnostic (no implementation details)
+  - SC text avoids "GitHub Actions API" / "gitleaks rule version" specifics; outcomes phrased as user-observable behavior
+- [x] All acceptance scenarios are defined
+  - 4 user stories × ~3-5 acceptance scenarios = 16 total scenarios covering happy path + edge cases
+- [x] Edge cases are identified
+  - 10 edge cases listed (cache miss / Dependabot major / gitleaks false positive / bundle bloat / fork no-protection / Actions outage 等)
+- [x] Scope is clearly bounded
+  - In-scope: 3 mandatory + 2 advisory + Dependabot + cache + dev container; out-of-scope explicitly listed (macOS / cross-platform diff / branch protection rules / perf regression / real Cloudflare integration)
+- [x] Dependencies and assumptions identified
+  - 10 assumptions + 8 dependencies enumerated
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+  - FR-001 → US3 #1; FR-003 → US1 #1-5; FR-008 → US4 #1-2 等對應明確
+- [x] User scenarios cover primary flows
+  - P1 newcomer + P2 maintainer + P2 fork + P3 reviewer 四象限完整
+- [x] Feature meets measurable outcomes defined in Success Criteria
+  - SC-001 (時間預算) / SC-003-006 (機械化失敗率) / SC-011 (baseline SC 升級) 直接對應 FR
+- [x] No implementation details leak into specification
+  - Spec 鎖契約(eg. "CI 必須以 .devcontainer/ image 跑 gates")而非鎖具體 Action 版本
+
+## Notes
+
+- All 13 checklist items pass on first pass (no iteration needed)
+- 6 clarification questions all answered upfront in user input;Clarifications § documents all 6 Q/A
+- Spec is ready for `/speckit-plan` (or `/speckit-clarify` if reviewer wants additional rigor on advisory job behavior or branch protection setup wording)
+- Recommend skipping `/speckit-clarify` and proceeding directly to `/speckit-plan` since all major design knobs were resolved upfront

--- a/specs/003-ci-workflow/contracts/ci-gates.md
+++ b/specs/003-ci-workflow/contracts/ci-gates.md
@@ -1,0 +1,369 @@
+# Contract: CI Gates(3 mandatory + 2 advisory job)
+
+**Feature**: `003-ci-workflow`
+**File anchor**: `.github/workflows/ci.yml`
+**Spec FR anchor**: FR-001~FR-005, FR-008~FR-011
+**Date**: 2026-05-03
+
+本契約定義 CI workflow 內 5 個 job 之 **input / output / failure mode / observable behavior**;以契約形式鎖定行為,使 Phase 2 tasks 與 Phase 3 implement 之 acceptance test 可逐項驗。
+
+---
+
+## §1 共通契約
+
+### 1.1 Trigger 條件
+
+| Event | 對 main branch | 行為 |
+|---|---|---|
+| `pull_request` | branches: [main] | 5 個 job 全跑(包含 advisory) |
+| `push` | branches: [main] | 5 個 job 全跑(merge 後驗證) |
+| `workflow_dispatch` | n/a | 手動觸發,5 個 job 全跑 |
+
+不在上表 trigger 之 event(如 `schedule` / `release`)**不觸發**本 workflow。
+
+### 1.2 Concurrency
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+- 同一 PR 連續 push:取消 in-progress 跑(只跑最新 commit)
+- main push 與 PR run 各自獨立 group(不互相取消)
+
+### 1.3 Runner
+
+`runs-on: ubuntu-latest`(GitHub-hosted x86_64)— 全 5 個 job 一致。Adopter self-hosted runner 屬 customization,本契約不涵蓋。
+
+### 1.4 Mandatory check 命名(用於 branch protection)
+
+| Job ID | Branch protection check name(adopter 須加入 Required status checks) |
+|---|---|
+| `gates` | `gates` |
+| `wrangler-bundle-check` | `wrangler-bundle-check` |
+| `secret-scan` | `secret-scan` |
+
+Job ID 與 check name 一致(GitHub Actions 預設行為),adopter 可在 Settings → Branches 直接加。
+
+---
+
+## §2 Mandatory Job:`gates`
+
+### 2.1 契約
+
+**目的**:在 dev container 內跑 4 mandatory gates(per 001 baseline workflow gates 1-3 + Worker pool)— typecheck / lint / test:node / test:worker。
+
+**Input**:
+
+- PR 之 commit SHA(由 `actions/checkout@v4` 取)
+- 既有 `.devcontainer/`(複用 image 定義)
+- 既有 `pnpm-lock.yaml`(install 鎖版)
+
+**Steps**:
+
+1. `actions/checkout@v4` — 取 PR diff(預設 fetch-depth: 1)
+2. `actions/cache@v4` — restore pnpm store(key: `pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}`)
+3. `actions/cache@v4` — restore node_modules(key: `node_modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}`)
+4. `devcontainers/ci@v0.3` — build(or restore)dev container image,然後 `runCmd` 跑:
+   ```bash
+   set -euo pipefail
+   pnpm install --frozen-lockfile
+   pnpm typecheck
+   pnpm lint
+   pnpm test:node
+   pnpm test:worker
+   ```
+5. (Optional)若 step 4 fail,`actions/upload-artifact@v4` 上傳 `*.log` / `.vitest-cache/` 供 reviewer download
+
+**Output**:
+
+- `success` exit:5 個 step 全綠 → job 標 ✅,branch protection 視為通過
+- `failure` exit:任一 step fail → job 標 ❌,GitHub Actions log 展示完整 stderr;branch protection 阻擋 merge
+
+**Failure mode**:
+
+| Step | Trigger | Visible behavior |
+|---|---|---|
+| `pnpm install --frozen-lockfile` fail | lockfile 與 manifest 不一致(per 001 FR-009)| log 展示 pnpm error;exit 1 |
+| `pnpm typecheck` fail | dual tsconfig 任一報 error(per 002 FR-022 Layer 1 + 既有 src/tests)| log 展示 tsc error 含 file:line |
+| `pnpm lint` fail | ESLint flat config 報 error,含 `no-restricted-imports` 跨 runtime 違規(per 002 FR-022 Layer 2)| log 展示 ESLint error 含 file:line |
+| `pnpm test:node` fail | vitest Node pool 任一 test 失敗 | log 展示 vitest output(失敗 test 名 + assertion diff) |
+| `pnpm test:worker` fail | vitest Worker pool(miniflare)任一 test 失敗 / setup fail | log 展示 vitest output;若是 cloudflare-pool worker startup 失敗(per 已解 issue #15 race condition)應由 0.15.2 patch bump 預防 |
+
+**性能契約**:
+
+- Cache hit 路徑:job 完成 ≤ 5 min(per SC-001)
+- Cache miss 路徑:job 完成 ≤ 15 min(per SC-001 + Edge Case)
+
+**Observable behavior(reviewer 視角)**:
+
+- ✅ 通過:GitHub PR 頁面 mandatory check `gates` 顯示綠勾;reviewer 不需手動跑 4 gate
+- ❌ 失敗:mandatory check `gates` 顯示紅叉;PR 頁面可點 check 直接看 GitHub Actions log 之 stderr 末段(含失敗 file:line)
+
+### 2.2 Spec impact
+
+- **001 FR-017** Ubuntu side mechanized(CI 在 dev container 內跑 4 gates)
+- **001 SC-002** partial mechanized(Ubuntu 內 4 gate 一致性自動驗;跨 Mac/WSL2 仍 manual)
+- **001 SC-005** mechanized(升版 commit 跑 4 gate 即證明 revert 可行)
+- **002 FR-022 + SC-011** 既有 mechanical guarantee 升為「每 PR 自動觸發」
+
+---
+
+## §3 Mandatory Job:`wrangler-bundle-check`
+
+### 3.1 契約
+
+**目的**:在 dev container 內跑 `wrangler deploy --dry-run` 產生 Worker bundle,然後 grep 確認不含 Node-only modules + 斷言 bundle size ≤ 100 KiB(per spec FR-003 第 2 條)。
+
+**Input**:
+
+- PR 之 commit SHA
+- 既有 `.devcontainer/` + `wrangler.jsonc` + `src/worker/`
+- Bundle budget threshold:100 KiB(per spec Q2 Clarification + research §4)
+
+**Steps**:
+
+1. `actions/checkout@v4`
+2. `actions/cache@v4` — restore pnpm store(同 §2.1 step 2)
+3. `actions/cache@v4` — restore node_modules(同 §2.1 step 3)
+4. `devcontainers/ci@v0.3` — build / restore + `runCmd` 跑:
+
+   ```bash
+   set -euo pipefail
+   pnpm install --frozen-lockfile
+   pnpm exec wrangler deploy --dry-run
+   BUNDLE=.wrangler/dryrun/index.js
+
+   # 檢查 1:bundle 不含 Node-only modules
+   FORBIDDEN=("pg" "redis" "pino" "prom-client" "@hono/node-server" "node:fs" "node:child_process")
+   for mod in "${FORBIDDEN[@]}"; do
+     if grep -q "$mod" "$BUNDLE"; then
+       echo "❌ BUNDLE CONTAINS FORBIDDEN MODULE: $mod"
+       grep -n "$mod" "$BUNDLE" | head -5
+       exit 1
+     fi
+   done
+
+   # 檢查 2:bundle size ≤ 100 KiB
+   SIZE=$(wc -c < "$BUNDLE")
+   BUDGET=$((100 * 1024))
+   if [ "$SIZE" -gt "$BUDGET" ]; then
+     echo "❌ BUNDLE SIZE $SIZE bytes (=$((SIZE / 1024)) KiB) exceeds budget $BUDGET bytes (=100 KiB)"
+     exit 1
+   fi
+   echo "✅ bundle clean: $SIZE bytes ($((SIZE / 1024)) KiB), budget $((BUDGET / 1024)) KiB"
+   ```
+
+**Output**:
+
+- `success`:bundle 不含 forbidden + size ≤ budget → job 標 ✅
+- `failure`:任一檢查 fail → job 標 ❌,log 展示具體違規
+
+**Failure mode**:
+
+| Trigger | Visible behavior |
+|---|---|
+| Bundle 含 `pg` / `redis` / `pino` / `prom-client` / `@hono/node-server` / `node:fs` / `node:child_process` 之一 | log 展示 `❌ BUNDLE CONTAINS FORBIDDEN MODULE: <name>` + grep 命中行;exit 1 |
+| Bundle size > 100 KiB | log 展示 `❌ BUNDLE SIZE N bytes (M KiB) exceeds budget 102400 bytes (100 KiB)`;exit 1 |
+| `wrangler deploy --dry-run` 自身 fail(eg. wrangler.jsonc 配置錯)| log 展示 wrangler error;exit 非 0 |
+| `pnpm install` fail | 同 §2.1 failure mode |
+
+**性能契約**:
+
+- Cache hit 路徑:job 完成 ≤ 3 min(install ~10s + wrangler dry-run ~30s + grep ~1s)
+- Cache miss 路徑:同 §2.1 ≤ 15 min budget
+
+**Observable behavior**:
+
+- ✅ 通過:check 顯示綠勾;若 reviewer 想知 size 趨勢,可看 log 之 ✅ 行(`bundle clean: N bytes`)
+- ❌ 失敗:check 顯示紅叉;log 直接列違規 module 或 size 超出量
+
+### 3.2 Spec impact
+
+- **002 FR-009** fully mechanized(從 typecheck 隱性攔下 → bundle-level 直接 grep)
+- **002 SC-003** fully mechanized(同上)
+- **新增約束**:Worker bundle size budget(spec.md SC-005)
+
+---
+
+## §4 Mandatory Job:`secret-scan`
+
+### 4.1 契約
+
+**目的**:用 gitleaks 掃 git diff(PR)或全 git history(push to main),確保無 OAuth credentials / `.env` 內容 / 看似 secret 的字串(per spec FR-003 第 3 條 + 001 SC-006)。
+
+**Input**:
+
+- PR diff(PR trigger)或全 git history(push to main trigger)
+- 可選 `.gitleaks.toml`(repo root)— allowlist 用於誤判(per data-model §1.3)
+
+**Steps**:
+
+1. `actions/checkout@v4` with `fetch-depth: 0`(取全 history,gitleaks scan diff 或 log 都需要 base ref)
+2. `gitleaks/gitleaks-action@v2` with:
+   - PR trigger:預設 mode(掃 PR diff,comment finding on PR diff line)
+   - push to main trigger:`GITLEAKS_NOTIFY_USER_LIST` 等 env 設定走 git log scan(掃全 history)
+   - 失敗時 redact secret value(只列 file + line),per FR-011
+
+**Output**:
+
+- `success`:0 finding → job 標 ✅
+- `failure`:≥ 1 finding → job 標 ❌,GitHub Actions log + PR diff annotation 展示 finding(file + line + redacted)
+
+**Failure mode**:
+
+| Trigger | Visible behavior |
+|---|---|
+| Commit 內含 `password=secret123` / 看似 OAuth token / `.env` 完整內容 | gitleaks finding 出現於 PR diff line(如 PR mode);log 展示 file + line(value redacted)|
+| 已有 `.gitleaks.toml` allowlist 但 finding 仍命中(allowlist 規則寫錯)| 同上;reviewer 須修 `.gitleaks.toml` |
+| Git history(non-PR-diff)內含舊 secret(historical leak) | 在 push to main mode 才會偵測;PR mode 只看 diff 不會 fire |
+
+**性能契約**:
+
+- PR mode(掃 diff):≤ 30 sec(gitleaks 快;diff 通常小)
+- push to main mode(掃全 history):≤ 1 min(中型 monorepo < 10k commits;per Edge Case 預期)
+
+**Observable behavior**:
+
+- ✅ 通過:check 顯示綠勾;PR diff 無 annotation
+- ❌ 失敗:check 紅叉;PR diff line 上直接出現 gitleaks bot annotation 含 redacted finding
+
+### 4.2 Spec impact
+
+- **001 SC-006** mechanized(從人工 / 偶發 → 每 PR + main push 自動)
+- **001 §Sensitive material policy** 全 ban list 機械化(`.claude/.credentials.json`、`.env`、`.dev.vars`、`*.pem`、`*.key`)
+
+---
+
+## §5 Advisory Job:`spec-coverage-advisory`
+
+### 5.1 契約
+
+**目的**:當 PR 動到 `src/**` 但無對應 `specs/NNN-*/` artifact,在 PR 內 comment 提示 reviewer 一案一案決定豁免(per spec FR-008 + 001 SC-003)。
+
+**Input**:
+
+- PR 之 file change list(從 GitHub API `pulls.listFiles`)
+
+**Steps**:
+
+1. `actions/checkout@v4`
+2. `actions/github-script@v7` — query PR file list,判斷:
+   - **Doc-only PR**(只動 `specs/**` / `.docs/**` / `*.md`):skip,不 comment(per FR-009)
+   - **動到 `src/**` + 動到 `specs/NNN-*/`(任一)**:OK,不 comment
+   - **動到 `src/**` 但無 `specs/NNN-*/` 變更**:**comment 提示**(本 advisory 之主要場景)
+
+3. Comment 內容:
+   ```text
+   ⚠ Advisory: This PR modifies `src/**` but no `specs/NNN-*/` artifact was added or updated.
+   Per 001 baseline FR-004 (spec-kit pipeline) + SC-003, non-trivial changes should
+   correspond to a spec directory. Reviewer please decide:
+   - (a) This is a trivial change exempt from spec coverage (per FR-004 trivial 豁免) — leave a comment explaining
+   - (b) Open a spec PR first, then update this PR to reference it
+   ```
+
+**Output**:
+
+- `success` exit code(無論是否 comment);**advisory 永不阻擋 merge**
+- 若觸發 comment,GitHub PR 頁面出現 bot comment(無 marker,每次 push 重 comment;per research §6 idempotency strategy)
+
+**Failure mode**:
+
+- 此 job 無「失敗」概念;skip 條件成立即不 comment,觸發條件成立即 comment;exit 0
+
+**Observable behavior**:
+
+- 在 advisory 觸發之 PR:reviewer 看到 bot comment,在 PR 內 留 reply 表態(豁免 / 駁回 / 補 spec)
+- 在 doc-only PR / 已有對應 spec/ 之 PR:reviewer 不會收到 noise
+
+### 5.2 Spec impact
+
+- **001 SC-003** advisory 化(從人工 attest → 自動提示;reviewer 仍保留豁免權)
+
+---
+
+## §6 Advisory Job:`toolchain-isolation-advisory`
+
+### 6.1 契約
+
+**目的**:當 PR 同時動 `package.json` / `pnpm-lock.yaml` 與 `src/**` / `tests/**`,comment 提示「toolchain 變更與 application 變更應分開 PR」(per spec FR-008 + 001 FR-019)。
+
+**Input**:
+
+- PR 之 file change list
+
+**Steps**:
+
+1. `actions/checkout@v4`
+2. `actions/github-script@v7`:
+   - **Doc-only PR**(只動 `specs/**` / `.docs/**` / `*.md`):skip
+   - **同時動 `package.json` 或 `pnpm-lock.yaml` AND 動 `src/**` 或 `tests/**`**:**comment 提示**
+   - 其他狀態:不 comment
+
+3. Comment 內容:
+   ```text
+   ⚠ Advisory: This PR modifies BOTH toolchain (`package.json` / `pnpm-lock.yaml`) AND
+   application code (`src/**` / `tests/**`). Per 001 baseline FR-019 + 002 spec assumption #6,
+   toolchain bumps should be isolated commits / PRs to enable single-commit revert.
+   Reviewer please decide:
+   - (a) Split into two PRs (recommended)
+   - (b) Leave a comment explaining why bundling is necessary (eg. dep upgrade requires src adaptation in same logical change)
+   ```
+
+**Output**:同 §5(advisory 永不阻擋 merge,exit 0)
+
+**Failure mode**:同 §5(無失敗概念)
+
+**Observable behavior**:
+
+- 觸發場景:reviewer 看 bot comment,決定要求拆 PR 或留 comment 豁免
+- 純 toolchain bump PR(eg. PR #17/#20)/ 純 app code PR:不會收到 noise
+
+### 6.2 Spec impact
+
+- **001 FR-019** advisory 化(從人工 attest → 自動提示;reviewer 仍保留豁免權)
+
+---
+
+## §7 不變量(must hold)
+
+1. **3 mandatory + 2 advisory total = 5 job**;不增刪(per spec FR-003 + FR-008)
+2. **Mandatory check failure 阻擋 merge**(via branch protection;adopter 設);**advisory failure 永不阻擋**
+3. **CI 不寫入 production credentials**(per spec FR-010 + 002 SC-004)— wrangler-bundle-check 用 dry-run;test:worker 用 miniflare;secret-scan 不需 secret(gitleaks 為 standalone)
+4. **Job 之間平行執行**(無 `needs:` chain),除非 follow-up implementation 發現 cache contention(本 plan 預設平行,Phase 3 implement 端驗證)
+5. **CI 跑於 ubuntu-latest**;不引入 macOS / Windows runner(per spec assumption + Q6 Clarification)
+6. **CI 工作於 dev container 內**(僅 gates + wrangler-bundle-check 兩 mandatory job;secret-scan + 兩 advisory 在 host 跑;per data-model §1.1)
+7. **Bundle budget 100 KiB 為當前 anchor**;升降走 isolated commit + reviewer 認可(per spec assumption #8)
+
+---
+
+## §8 失敗模式表(summary)
+
+| 場景 | 哪個 job fail | 阻擋 merge? | reviewer 行動 |
+|---|---|---|---|
+| typecheck error | gates | ✅ Yes | 修 src 或 spec amendment |
+| ESLint error / no-restricted-imports 觸發 | gates | ✅ Yes | 修 import 或合理重構 |
+| vitest test fail(Node or Worker pool) | gates | ✅ Yes | 修 test 或 implementation |
+| Worker bundle 含 forbidden module | wrangler-bundle-check | ✅ Yes | 移除違規 dep / import |
+| Worker bundle size > 100 KiB | wrangler-bundle-check | ✅ Yes | 縮 bundle 或 isolated commit 升 budget |
+| Git diff 含 OAuth / `.env` / 看似 secret | secret-scan | ✅ Yes | 移除 secret 並 rotate;若誤判加 `.gitleaks.toml` allowlist |
+| PR 動 src 但無 spec | spec-coverage-advisory | ❌ No | 看 comment 決定豁免 / 補 spec |
+| PR 同時動 deps + src | toolchain-isolation-advisory | ❌ No | 看 comment 決定拆 PR / 豁免 |
+
+---
+
+## §9 驗證(per Phase 3 `/speckit-implement` 之 acceptance test)
+
+對應 spec.md §「必須涵蓋的 acceptance scenarios」:
+
+| Spec scenario | Implementation 階段如何驗 |
+|---|---|
+| 乾淨 fork 開首個 PR → 3 mandatory check 跑 | 把 003 PR 自身 push,看 GitHub Actions tab 出現 3 check |
+| PR 加 `import { Pool } from 'pg'` 至 `src/worker/` → gates lint fail | 開 negative test PR(可 squash 後 close);看 gates job 之 lint 步驟 fail |
+| PR 引入 dep 撐破 100 KiB bundle → wrangler-bundle-check fail | 開 negative test PR;看 wrangler-bundle-check fail with size message |
+| PR commit 含 fake secret → secret-scan fail | 開 negative test PR(用 gitleaks 之 known fake pattern,不洩漏真實 secret);看 secret-scan fail |
+| PR 動 src 無 spec → advisory comment | 開 trivial src-only PR,看 spec-coverage-advisory comment 出現 |
+| PR 同時動 deps + src → advisory comment | 開 PR 同時 touch `package.json` + `src/`;看 toolchain-isolation-advisory comment 出現 |
+
+證據存於 `quickstart.md` § Negative test walkthrough。

--- a/specs/003-ci-workflow/contracts/dependabot-policy.md
+++ b/specs/003-ci-workflow/contracts/dependabot-policy.md
@@ -1,0 +1,228 @@
+# Contract: Dependabot Policy
+
+**Feature**: `003-ci-workflow`
+**File anchor**: `.github/dependabot.yml`
+**Spec FR anchor**: FR-006, FR-007
+**Date**: 2026-05-03
+
+本契約定義 `.github/dependabot.yml` 之 schedule + grouping rules + commit convention + target branch 之契約;以契約形式鎖定行為,使 Phase 2 tasks 與 Phase 3 implement 之 acceptance test 可逐項驗。
+
+---
+
+## §1 共通契約
+
+### 1.1 Configuration version
+
+`version: 2`(Dependabot v2 schema;v1 已 deprecate,本 feature 不支援)
+
+### 1.2 Ecosystem 涵蓋
+
+兩條 `updates` entry:
+
+| Ecosystem | Directory | Purpose |
+|---|---|---|
+| `npm` | `/`(repo root,monorepo 單一 `package.json`)| 掃 `dependencies` + `devDependencies` 之升版 |
+| `github-actions` | `/`(repo root,GitHub 約定路徑)| 掃 `.github/workflows/*.yml` 內之 action 版本(per research §12 + plan §Technology Stack) |
+
+不涵蓋之 ecosystem(adopter 自行加,屬 customization):
+- `docker`(本 monorepo 之 Docker base image 升版屬 dev container 維護,不在 Dependabot 自動掃範圍;可由 maintainer 手動或 follow-up feature 加)
+- `pip` / `bundler` / 其他語言 ecosystem(本 monorepo 不引入)
+
+---
+
+## §2 npm entry 契約
+
+### 2.1 結構
+
+```yaml
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+    # time: "09:00"  # 預設 GitHub-managed timezone (UTC),不額外鎖
+  open-pull-requests-limit: 5
+  target-branch: "main"
+  commit-message:
+    prefix: "chore(deps)"
+    include: "scope"
+  groups:
+    cloudflare-ecosystem:
+      patterns:
+        - "@cloudflare/*"
+        - "wrangler"
+        - "miniflare"
+      update-types: ["minor", "patch"]
+    typescript-eslint:
+      patterns:
+        - "@typescript-eslint/*"
+        - "typescript-eslint"
+      update-types: ["minor", "patch"]
+    vitest:
+      patterns:
+        - "@vitest/*"
+        - "vitest"
+      update-types: ["minor", "patch"]
+    node-deps-minor-patch:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "@cloudflare/*"
+        - "wrangler"
+        - "miniflare"
+        - "@typescript-eslint/*"
+        - "typescript-eslint"
+        - "@vitest/*"
+        - "vitest"
+      update-types: ["minor", "patch"]
+```
+
+### 2.2 不變量
+
+1. **Schedule**:每週一(Monday)觸發;頻率 `weekly`(per spec FR-006)。**不改頻率為 daily**(會增加 PR noise)
+2. **Target branch**:`main`(per spec FR-006);Dependabot 開 PR target 即 main,自動觸發本 feature CI
+3. **Open PR limit**:`5`(per spec FR-007);超出即 Dependabot 暫停開新 PR 直到 maintainer merge / close 既有 PR
+4. **Commit message convention**:`chore(deps): bump xxx`(per 001 FR-019;`prefix: "chore(deps)"` + `include: "scope"` 自動產出此格式)
+5. **Grouping rules**:4 條 minor+patch group(cloudflare-ecosystem / typescript-eslint / vitest / node-deps-minor-patch);**major 不 group**(Dependabot 預設行為,各自獨立 PR)
+
+### 2.3 Grouping rules 詳細(per research §5)
+
+| Group name | Patterns | Why |
+|---|---|---|
+| `cloudflare-ecosystem` | `@cloudflare/*`, `wrangler`, `miniflare` | issue #15 root-cause:transitive workerd / wrangler 版本 dedupe drift;同組升保證對齊 |
+| `typescript-eslint` | `@typescript-eslint/*`, `typescript-eslint` | parser + plugins + rules 須同版本 |
+| `vitest` | `@vitest/*`, `vitest` | core + runner + spy 須同版本 |
+| `node-deps-minor-patch` | `*` exclude 上面三組 | 其他 minor + patch 一組,降低 PR noise |
+| (no group) | major bumps | 各自獨立 PR;避免 breaking change 被遮蔽 |
+
+### 2.4 Failure mode
+
+| Trigger | Visible behavior |
+|---|---|
+| 某 dep 有 minor 升版 | Dependabot 在週一掃時加入該 dep 對應 group 的 PR;若該 group 無其他升版,單 dep 一 PR |
+| 某 dep 有 major 升版 | Dependabot 開 separate PR(不入 group);CI 跑後 maintainer 看 break 程度 |
+| 某 dep 有 security advisory | Dependabot 立即開 PR(不等週一);本 contract 不阻擋 security 升版 |
+| Open PR 超過 5 | Dependabot 暫停開新 PR;maintainer 須 merge / close 部分 PR 才繼續 |
+| Dep 從 npm 被 unpublish / 取消 | Dependabot PR 開不出,記錄在 GitHub repo 之 Dependabot insights tab |
+
+### 2.5 Observable behavior(maintainer 視角)
+
+- **Weekly Monday morning(GitHub UTC)**:Dependabot tab 出現新 PR(若有可升)
+- **PR title 範例**:
+  - `chore(deps): bump @cloudflare/vitest-pool-workers from 0.15.2 to 0.15.3`(單 dep)
+  - `chore(deps): bump cloudflare-ecosystem group with 2 updates`(多 dep 同組)
+- **PR 自動觸發 CI**(本 feature workflow);CI 跑綠 maintainer 即可 merge
+
+---
+
+## §3 github-actions entry 契約
+
+### 3.1 結構
+
+```yaml
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  open-pull-requests-limit: 3
+  target-branch: "main"
+  commit-message:
+    prefix: "chore(deps)"
+    include: "scope"
+  groups:
+    github-actions-minor-patch:
+      patterns:
+        - "*"
+      update-types: ["minor", "patch"]
+```
+
+### 3.2 不變量
+
+1. **Schedule**:同 §2.2 #1
+2. **Target branch**:`main`
+3. **Open PR limit**:`3`(github-actions 升版頻率比 npm 低,limit 設小)
+4. **Commit convention**:`chore(deps): bump xxx`(同 §2.2 #4)
+5. **Grouping**:1 條 group 涵蓋所有 github-actions minor+patch;major 各自獨立 PR
+
+### 3.3 涵蓋之 GitHub Actions(per plan §Technology Stack):
+
+| Action | 當前 pin | 升版掃描 |
+|---|---|---|
+| `actions/checkout` | `@v4` | 監控 v5 / patch |
+| `pnpm/action-setup` | `@v4` | 監控 v5 / patch |
+| `actions/cache` | `@v4` | 監控 v5 / patch |
+| `actions/github-script` | `@v7` | 監控 v8 / patch |
+| `devcontainers/ci` | `@v0.3` | 監控 v0.4 / v1 / patch |
+| `gitleaks/gitleaks-action` | `@v2` | 監控 v3 / patch |
+
+### 3.4 Failure mode
+
+| Trigger | Visible behavior |
+|---|---|
+| 某 action 有 minor 升版 | Dependabot 加入 `github-actions-minor-patch` group 之 PR(每週掃) |
+| 某 action 有 major 升版 | Dependabot 開 separate PR;CI 跑後 maintainer 看 break 程度 |
+
+### 3.5 Observable behavior
+
+- 同 §2.5,但 PR 動 `.github/workflows/*.yml` 而非 `package.json`
+- CI workflow 自身被 PR 動到時,**用 PR 之新版 ci.yml 跑**(per Edge Case + spec SC-009)— self-test 通過即可 merge
+
+---
+
+## §4 與其他 contracts 之關係
+
+### 4.1 與 `ci-gates.md` 之關係
+
+- Dependabot 開之 PR 自動觸發本 feature 之 CI workflow(per §1.1 trigger `pull_request`)
+- 5 個 job 全跑(包含 advisory)
+- **預期**:大多數 patch / minor bump → CI 跑綠 → maintainer 一鍵 merge
+- **預期**:major bump → CI 可能 fail(breaking change)→ maintainer 手動 root-cause
+
+### 4.2 與既有 PR 慣例之關係
+
+- 本 contract 之 commit message convention `chore(deps): bump xxx` 對齊既有(per session memory PR #17 / PR #20 等已用此格式)
+- 本 contract 不引入新 PR title rule;Dependabot 預設 title 即 `chore(deps): ...`
+
+### 4.3 與 Constitution 之關係
+
+- 對齊憲法 §Toolchain pinning「The same isolation rule applies to upgrading wrangler, vitest, and other CORE toolchain items」 — Dependabot 自動 isolate 升版至 separate PR
+- 對齊 plan §Constitution Check III(toolchain bump 走 isolated commit)
+
+---
+
+## §5 不變量(must hold)
+
+1. **2 ecosystems**(npm + github-actions);不增刪 ecosystems(per §1.2 + spec FR-006)
+2. **每週一掃**;不改頻率(per §2.2 #1 + §3.2 #1)
+3. **Target branch = main**;不改(per §2.2 #2 + §3.2 #2)
+4. **Commit convention = `chore(deps): bump xxx`**;不改(per 001 FR-019 + 既有慣例)
+5. **Open PR limit**:npm 5 / github-actions 3;升降走 isolated commit + reviewer 認可
+6. **npm 之 4 grouping rules + github-actions 之 1 grouping rule** 為當前 anchor;升降走 isolated commit
+7. **Major bump 不 group**(Dependabot 預設行為);本 contract 不 override 為「major 也 group」
+8. **Security advisory 之 PR 不受 schedule 限制**(Dependabot 立即開);本 contract 不阻擋(per §2.4)
+
+---
+
+## §6 失敗模式表(summary)
+
+| 場景 | 預期 Dependabot 行為 | maintainer 行動 |
+|---|---|---|
+| `@cloudflare/vitest-pool-workers` 0.15.2 → 0.15.3(patch) | 加入 cloudflare-ecosystem group PR | CI 跑綠即 merge |
+| `wrangler` 4.87.0 → 5.0.0(major) | 開 separate PR,標 [`major`] label | CI 看 break;若 break 小可同 PR 修;若大 close PR 暫不升 |
+| 多 dep 同週可升(eg. wrangler + workers-types + vitest-pool-workers 同有 patch) | 加入 cloudflare-ecosystem group 一 PR(對齊 transitive) | CI 跑綠即 merge,issue #15 之 dedupe drift 不會復現 |
+| ESLint 9 → 10(major) | 開 separate PR | 看 break;ESLint major 通常需 config migration |
+| `gitleaks/gitleaks-action` v2 → v3(major) | 開 separate PR | CI 跑綠即 merge(secret-scan job 仍能跑代表向後相容) |
+
+---
+
+## §7 驗證(per Phase 3 `/speckit-implement` 之 acceptance test)
+
+對應 spec.md §「必須涵蓋的 acceptance scenarios」第 2~4 條:
+
+| Spec scenario | Implementation 階段如何驗 |
+|---|---|
+| Dependabot 配置就位,週一觸發 | merge 003 PR 後等下週一(2026-05-04 為週一)觀察 GitHub PR tab 是否出現 Dependabot PR(若 deps 都 latest 可能無;此驗證在「Dependabot 已啟用」的層次,而非「PR 必開」) |
+| Dependabot PR 觸發 CI | 任一 Dependabot PR 開後看 Actions tab 跑 5 job |
+| Cloudflare ecosystem 同組升版 | 等 cloudflare-ecosystem 群組內任 ≥ 2 dep 同週可升時觀察(opportunistic;若一年內未發生屬正常) |
+| Commit message convention | merge 一個 Dependabot PR 後 `git log -1 --format='%s'` 應為 `chore(deps): bump xxx` |

--- a/specs/003-ci-workflow/data-model.md
+++ b/specs/003-ci-workflow/data-model.md
@@ -1,0 +1,266 @@
+# Data Model: 003-ci-workflow
+
+**Feature**: `003-ci-workflow`
+**Phase**: 1 (Design)
+**Date**: 2026-05-03
+**Status**: Light scope — CI workflow 為 declarative configuration,無 application data model;本檔記錄 spec.md §Key Entities 之結構性 entity 與其關係。
+
+> 本 feature 屬 CI/CD configuration-only(per plan.md §Project Type),不引入新 application entity / state machine / 持久化資料。本檔聚焦於「configuration entity 之結構與關係」,以便 Phase 2 tasks 能依 entity 拆分檔案落地。
+
+---
+
+## §1 Configuration Entities
+
+### 1.1 CI Workflow
+
+**檔案**: `.github/workflows/ci.yml`
+
+**結構**:
+
+| 欄位 | 型別 | 內容 |
+|---|---|---|
+| `name` | string | `CI`(或 `Quality Gates`,於 plan 階段不鎖,implement 階段決定) |
+| `on` | object | trigger:`pull_request` to main + `push` to main + `workflow_dispatch` |
+| `concurrency` | object | group + cancel-in-progress(per research §7) |
+| `jobs` | object | 5 個 job(3 mandatory + 2 advisory) |
+
+**Job 列表**:
+
+| Job ID | 性質 | 在 branch protection 內? | failure 阻擋 merge? |
+|---|---|---|---|
+| `gates` | mandatory | ✅ | ✅ |
+| `wrangler-bundle-check` | mandatory | ✅ | ✅ |
+| `secret-scan` | mandatory | ✅ | ✅ |
+| `spec-coverage-advisory` | advisory | ❌ | ❌(僅 PR comment) |
+| `toolchain-isolation-advisory` | advisory | ❌ | ❌(僅 PR comment) |
+
+**關係**:
+
+- 所有 job 皆 `runs-on: ubuntu-latest`
+- `gates` + `wrangler-bundle-check` 均**於 dev container 內執行**(per FR-004;研究 §1 選 `devcontainers/ci@v0.3`)
+- `secret-scan` 不需 dev container(gitleaks 為 standalone Action;research §2)
+- 兩條 advisory job 在 host 跑(GitHub-script;research §6)
+- 各 job 平行執行(無 `needs:` chain),除非 reviewer 後續發現需序列化(eg. share `pnpm install` artifact 跨 job)— 本 plan 假設平行,initial implementation 即驗證
+
+### 1.2 Dependabot Configuration
+
+**檔案**: `.github/dependabot.yml`
+
+**結構**:
+
+| 欄位 | 型別 | 內容 |
+|---|---|---|
+| `version` | int | `2`(Dependabot v2 schema) |
+| `updates` | array of object | 兩條 entry:`npm` + `github-actions` |
+
+**npm entry**(per research §5):
+
+| 欄位 | 值 |
+|---|---|
+| `package-ecosystem` | `npm` |
+| `directory` | `/` |
+| `schedule.interval` | `weekly` |
+| `schedule.day` | `monday` |
+| `open-pull-requests-limit` | `5` |
+| `target-branch` | `main` |
+| `commit-message.prefix` | `chore(deps)` |
+| `commit-message.include` | `scope` |
+| `groups` | 4 條(per research §5):cloudflare-ecosystem / typescript-eslint / vitest / node-deps-minor-patch |
+
+**github-actions entry**:
+
+| 欄位 | 值 |
+|---|---|
+| `package-ecosystem` | `github-actions` |
+| `directory` | `/` |
+| `schedule.interval` | `weekly` |
+| `schedule.day` | `monday` |
+| `open-pull-requests-limit` | `3` |
+| `target-branch` | `main` |
+| `commit-message.prefix` | `chore(deps)` |
+| `commit-message.include` | `scope` |
+| `groups` | 1 條:github-actions-minor-patch |
+
+### 1.3 Optional gitleaks allowlist
+
+**檔案**: `.gitleaks.toml`(repo root,**初版不建立**;僅當 false positive 出現時於 isolated PR 內加)
+
+**結構**(when needed):
+
+```toml
+[allowlist]
+description = "False positives reviewed in PR #N"
+paths = [
+  '''path/to/file\.md''',
+]
+regexes = [
+  '''specific-pattern''',
+]
+```
+
+每次加 entry 須 PR review 驗證確實非 secret(per spec edge case)。
+
+### 1.4 README §「CI status」
+
+**檔案**: `README.md`(append section)
+
+**結構**:
+
+| 子段 | 內容 |
+|---|---|
+| Badge URL | GitHub Actions badge:`https://github.com/<org>/<repo>/actions/workflows/ci.yml/badge.svg` |
+| 行為簡述 | 3 mandatory(gates / wrangler-bundle-check / secret-scan)+ 2 advisory + Dependabot 摘要 |
+| Branch protection 指引 | per research §10 之操作步驟 |
+| Quickstart 連結 | `specs/003-ci-workflow/quickstart.md` |
+
+---
+
+## §2 Job 之 Step 拓樸(Phase 2 tasks 拆分依據)
+
+### 2.1 `gates` job(mandatory)
+
+```text
+gates job
+├── checkout (actions/checkout@v4)
+├── setup pnpm cache (actions/cache@v4, key=pnpm-store-...)
+├── setup node_modules cache (actions/cache@v4, key=node_modules-...)
+├── run dev container + 4 gates (devcontainers/ci@v0.3)
+│   └── inside container:
+│       ├── pnpm install --frozen-lockfile
+│       ├── pnpm typecheck
+│       ├── pnpm lint
+│       ├── pnpm test:node
+│       └── pnpm test:worker
+└── upload logs on failure (optional, actions/upload-artifact@v4)
+```
+
+### 2.2 `wrangler-bundle-check` job(mandatory)
+
+```text
+wrangler-bundle-check job
+├── checkout (actions/checkout@v4)
+├── setup pnpm cache (shared key with gates job)
+├── setup node_modules cache (shared key with gates job)
+├── run dev container (devcontainers/ci@v0.3)
+│   └── inside container:
+│       ├── pnpm install --frozen-lockfile
+│       ├── pnpm exec wrangler deploy --dry-run
+│       ├── grep bundle for forbidden modules (per research §4)
+│       └── assert bundle size ≤ 100 KiB
+```
+
+### 2.3 `secret-scan` job(mandatory)
+
+```text
+secret-scan job
+├── checkout (actions/checkout@v4 with fetch-depth: 0)
+│   ├── on PR: fetch-depth: 0 (full history for diff base)
+│   └── on push to main: fetch-depth: 0 (全 history)
+└── gitleaks scan (gitleaks/gitleaks-action@v2)
+    ├── on PR: GITLEAKS_ENABLE_COMMENTS=true (comment finding on PR)
+    └── on push to main: scan all (掃 git log)
+```
+
+### 2.4 `spec-coverage-advisory` job(advisory)
+
+```text
+spec-coverage-advisory job
+├── checkout (actions/checkout@v4)
+├── check if doc-only PR (actions/github-script@v7, per research §11)
+│   └── if doc-only: skip remaining steps
+└── post advisory comment if src/ touched but specs/ not (actions/github-script@v7)
+```
+
+### 2.5 `toolchain-isolation-advisory` job(advisory)
+
+```text
+toolchain-isolation-advisory job
+├── checkout (actions/checkout@v4)
+├── check if doc-only PR (same as spec-coverage)
+│   └── if doc-only: skip remaining steps
+└── post advisory comment if package.json + src/ both touched
+```
+
+---
+
+## §3 Entity 互動關係圖
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  GitHub Repo Settings (out of scope, adopter manual)            │
+│  └─ Branch Protection Rule for `main`                           │
+│     └─ Required status checks:                                  │
+│        ├─ gates                                                 │
+│        ├─ wrangler-bundle-check                                 │
+│        └─ secret-scan                                           │
+└─────────────────────────────────────────────────────────────────┘
+                                ▲
+                                │ enforces (manual)
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│  .github/workflows/ci.yml (FR-001~005, FR-008~011)              │
+│  ├─ on: pull_request | push | workflow_dispatch                 │
+│  ├─ concurrency: cancel-in-progress per ref                     │
+│  └─ jobs:                                                       │
+│     ├─ gates ────────────────────┐                              │
+│     ├─ wrangler-bundle-check ────┼─ uses .devcontainer/ image  │
+│     ├─ secret-scan ──────────────┼─ uses gitleaks-action@v2   │
+│     ├─ spec-coverage-advisory ───┤                              │
+│     └─ toolchain-isolation-advisory                             │
+└──────────────┬──────────────────────────────────────────────────┘
+               │
+               │ posts PR comments
+               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  GitHub PR (US1, US4)                                           │
+│  ├─ Status checks: 3 mandatory ✓ / ✗                            │
+│  ├─ PR comments (advisory):                                     │
+│  │   ├─ ⚠ src changed without spec/                             │
+│  │   └─ ⚠ deps + src in same PR                                 │
+│  └─ Reviewer reads → merge or request change                    │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│  .github/dependabot.yml (FR-006~007)                            │
+│  ├─ npm entry: weekly Monday, 4 groups, 5 PR limit              │
+│  └─ github-actions entry: weekly Monday, 1 group, 3 PR limit    │
+└──────────────┬──────────────────────────────────────────────────┘
+               │
+               │ opens PRs
+               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Dependabot upgrade PR (US2)                                    │
+│  ├─ Title / commit message: chore(deps): bump xxx               │
+│  ├─ Triggers same CI workflow above                             │
+│  └─ Maintainer reviews CI result → merge / close / fix          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## §4 與 spec.md §Key Entities 對齊驗證
+
+| spec.md Entity | 本檔 §section | 落地檔案 |
+|---|---|---|
+| CI Workflow | §1.1 | `.github/workflows/ci.yml` |
+| Dev Container Image | §1.1 + §2.1/2.2 | 複用既有 `.devcontainer/`(本 feature 不修改) |
+| Bundle Budget | §1.1(`wrangler-bundle-check` job)+ §2.2 | inline 於 ci.yml(初版),budget 升降走 isolated commit |
+| Secret Scan Configuration | §1.3 | `.gitleaks.toml`(optional,需要時加) |
+| Dependabot Configuration | §1.2 | `.github/dependabot.yml` |
+| Advisory Comment | §1.1(2 個 advisory job)+ §2.4/2.5 | inline 於 ci.yml(actions/github-script) |
+| Branch Protection Mandatory Check List | §3 圖頂部 | **不在本 feature 範圍**;adopter 手動設(per Out of scope + research §10) |
+
+✅ 100% 對齊 spec.md §Key Entities 7 條,無遺漏。
+
+---
+
+## §5 結論與下一步
+
+Data model 完成。本 feature 為 CI configuration scope,entity 集中於 4 檔案:
+
+- `.github/workflows/ci.yml`(主要)
+- `.github/dependabot.yml`
+- `.gitleaks.toml`(optional)
+- `README.md`(append §「CI status」)
+
+無 application data model / state machine / persistent storage。下一步 Phase 1 contracts 將定義各 job 之 input / output / failure mode 之契約。

--- a/specs/003-ci-workflow/plan.md
+++ b/specs/003-ci-workflow/plan.md
@@ -1,0 +1,186 @@
+# Implementation Plan: CI Workflow + Dependabot — Ubuntu Mechanization of Baseline Gates
+
+**Branch**: `003-ci-workflow` | **Date**: 2026-05-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/003-ci-workflow/spec.md`
+
+## Summary
+
+機械化既有 4 mandatory gates(`pnpm typecheck` / `pnpm lint` / `pnpm test:node` / `pnpm test:worker`)+ 新增 wrangler bundle 純度檢查 + secret scan + Dependabot 自動升版 + 兩條 advisory 提示,**全部於 GitHub Actions ubuntu-latest runner 內以 dev container image 執行**。本 feature 不引入新 application code,只配置 CI workflow YAML(`.github/workflows/ci.yml`)+ Dependabot 配置(`.github/dependabot.yml`)+ optional `.gitleaks.toml` allowlist + README §「CI status」。
+
+## Technical Context
+
+**Language/Version**:
+
+- 主要 artifact 為 GitHub Actions Workflow YAML(YAML 1.2)+ Dependabot 配置 YAML
+- Advisory job 內可能含少量 Bash(LF 行尾 + ShellCheck 友好)
+- 不引入 application TS / JS code
+
+**Primary Dependencies**:
+
+- GitHub Actions service(adopter 端,fork 必需)
+- GitHub Actions Marketplace actions:`actions/checkout@v4`、`pnpm/action-setup@v4`、`devcontainers/ci@v0.3`、`gitleaks/gitleaks-action@v2`、`actions/cache@v4`、`actions/github-script@v7`(advisory comment 用)
+- 既有 `.devcontainer/`(複用,本 feature 不修改 devcontainer 定義)
+- 既有 `pnpm-lock.yaml`(cache key 來源)
+
+**Storage**: N/A(本 feature 為 CI 配置,無持久化資料)
+
+**Testing**:
+
+- 主要驗證:CI workflow 自身 push 後在 GitHub Actions UI 跑綠;negative test 用 PR 故意違規(eg. 加 `import 'pg'` 進 worker / 加大 bundle / commit fake secret)驗 mandatory check 確實 fail
+- 不引入新 vitest / typecheck test;本 feature 之 acceptance 由「CI 跑綠/紅」直接驗證
+
+**Target Platform**:
+
+- CI runner:`ubuntu-latest`(GitHub-hosted x86_64)
+- Dev container image:`.devcontainer/Dockerfile` 描述之 image(複用,基於 Debian/Ubuntu)
+- Adopter:任何 GitHub repo(public free tier 或 private paid)
+
+**Project Type**: CI/CD configuration(YAML-as-code)
+
+**Performance Goals**:
+
+- SC-001:cache hit ≤ 5 min;cache miss ≤ 15 min
+- SC-007:Dependabot PR 跑完 ≤ 15 min(同上)
+- SC-008:fork 後 ≤ 5 min 內 CI 自動偵測(GitHub Actions 之偵測延遲)
+
+**Constraints**:
+
+- 不寫入 production credentials(per FR-010)
+- 不打真 Cloudflare API(wrangler-bundle-check 用 `--dry-run`;test:worker 用 miniflare)
+- 不 fork / 維護 secret 規則庫(用 gitleaks 預設 + `.gitleaks.toml` allowlist;per Assumption #4)
+- macOS runner 排除(per Q6 Clarification + Assumption #1)
+
+**Scale/Scope**:
+
+- Repo scale:中型 monorepo(< 10k commits / < 1000 files);gitleaks 全 history scan 預期 < 1 min
+- CI 觸發頻率:預期 < 50 PR/月(典型 OSS starter 規模);GitHub Actions free tier minutes 充足
+
+## Constitution Check
+
+> Constitution v1.1.3 (2026-05-03)。本節對齊 5 Core Principles + Variant Amendment + Technology Stack + Workflow Quality Gates 各條,記錄合規性。
+
+### I. Test-First Development (NON-NEGOTIABLE) — ✅ N/A with documented rationale
+
+本 feature 不引入 application code;所有 artifact 為 declarative YAML 配置 + 可能少量 advisory job 之 Bash glue。**TDD 不直接適用** — workflow YAML 之「test」即「真實在 GitHub Actions 跑」,RED→GREEN 階段對應「commit workflow 至 PR」→「看 GitHub Actions 結果」。
+
+豁免依據:憲法 V 原則之 trivial 豁免(「typos, single-line bugs, dependency bumps with no behavior change」)精神延伸 — CI 配置變更不引入 application behavior change,但本 feature 仍走完整 spec-kit pipeline(spec → plan → tasks → implement)以兌現 baseline FR-017 形式上的「機械化」門檻。
+
+實際 acceptance 測試方式:
+
+- **Positive**:本 PR 自身會被新 CI workflow 跑(per Edge Case「PR 動到 ci.yml 自身」),若新 ci.yml 寫壞,PR 即失敗
+- **Negative**:`/speckit-implement` 階段會故意 push 違規 PR(eg. add `import 'pg'` to `src/worker/`)驗 gates job lint 確實 fail;故意加大 bundle 驗 wrangler-bundle-check 確實 fail;加 fake secret 驗 secret-scan 確實 fail。這些 negative 測試之證據存於 `quickstart.md`
+
+### II. Observability by Default — ✅ N/A
+
+本 feature 不引入新 application 進程,無新 observability surface。CI log 為 GitHub Actions 內建 surface,本 feature 不額外加 metrics / structured logging。FR-011 規範 CI 失敗訊息對 reviewer 直觀(直接展示 stderr 末段),屬 GitHub Actions 內建行為,無需額外實作。
+
+### III. Container-First Development, Per-Runtime Deployment — ✅ COMPLIANT
+
+**對齊核心**:憲法 III 寫「CI MUST execute on the same base image as the dev container (Node side)」— 本 feature **直接兌現**此承諾。FR-004 鎖定「CI 必須以 `.devcontainer/` 內定義之 image 跑 gates」之契約,具體技術選擇(`devcontainers/ci@v0.3` GitHub Action)於 Phase 0 research.md 比較後決定。
+
+**ARM/x86 platform**:CI 跑於 ubuntu-latest(x86_64);dev container image 為多架構,於 Mac M1(arm64) + WSL2(x86_64)本機執行已驗 parity(per `.docs/parity-validation.md` 2026-05-03 strict-pair record)。CI 端只跑 x86_64,即與 WSL2 host 同架構;Mac arm64 parity 由本機驗證承擔(SC-002 不在本 feature 範圍)。
+
+**Per-runtime deployment unaffected**:本 feature 不動 `Dockerfile`、`docker-compose.yml`、`wrangler.jsonc`,Node 與 Worker 之 production deployment 路徑不變。
+
+### IV. Type Safety End-to-End — ✅ COMPLIANT
+
+本 feature 之 artifact 主要為 YAML(strict 模式不適用),少量 Bash glue 須:
+
+- LF 行尾(per `.gitattributes`)
+- ShellCheck-friendly(advisory job 內若有 Bash)
+- 不修改既有 `tsconfig*.json` / `eslint.config.js`(本 feature 把既有規則升至 CI 機械驗,不放鬆/收緊規則)
+
+### V. Spec-Driven Development — ✅ COMPLIANT + ENHANCING
+
+本 feature 自身走 spec-kit pipeline(`/speckit-specify` → `/speckit-clarify`(跳過,knobs 已預解)→ `/speckit-plan`(本檔)→ `/speckit-tasks` → `/speckit-implement`)。
+
+**Enhancing**:本 feature FR-008 加 SC-003 spec coverage advisory job,自動偵測「動 src/ 但無 specs/」並 comment 提示;此為憲法 V「Spec coverage」gate 之機械化提示(reviewer 仍保留豁免權)。
+
+**人類 review gate 保留**:本 plan 完成後,要求人類 review `spec.md` + `plan.md` 才執行 `/speckit-implement`(per 憲法 V「A human reviewer MUST inspect ... BEFORE `/speckit-implement` runs」)。
+
+### Variant Amendment — Cloudflare Worker Companion — ✅ COMPLIANT
+
+- **Per-runtime deployment**:本 feature 不變更 wrangler / Docker 之 deployment 路徑;wrangler-bundle-check job 用 `--dry-run` 不實際 deploy。✓
+- **Type Safety End-to-End fully mechanical (v1.1.3)**:本 feature 之 gates job 跑 `pnpm lint` 即觸發既有 `eslint.config.js` `no-restricted-imports` rule(Layer 2);跑 `pnpm typecheck` 即觸發既有雙 tsconfig(Layer 1)。本 feature **不放鬆** v1.1.3 機械化保證,反而升級為「每 PR 自動觸發 → 違規 PR 直接被擋」。✓
+- **Test-First continues — dual pool**:本 feature gates job 完整跑 `pnpm test:node` + `pnpm test:worker` 兩 pool;不跳過 worker pool。✓
+- **Comparison demos are first-class**:本 feature 不影響既有 README 3×2 對照表(FR-012 加 §「CI status」段為新增,不取代既有段)。✓
+
+### Technology Stack & Constraints — ✅ COMPLIANT
+
+- **CORE toolchain**:本 feature 不變更 TypeScript / Hono / vitest / ESLint / Prettier / pnpm 任一 CORE 項目之版本;只把既有命令升至 CI。✓
+- **Toolchain pinning isolation**:本 feature 引入之 GitHub Actions(`actions/checkout@v4` etc.)版本固定即屬 toolchain pinning 範圍;未來升版走 isolated commit(per 憲法 §Toolchain pinning + spec FR-019)。✓ 此外 Dependabot 配置之 `package-ecosystem: github-actions` 條目自動處理 GitHub Actions 升版掃描。
+- **Worker bundle policy**:wrangler-bundle-check job 直接機械驗(grep + size assertion)— 同 `tsconfig.worker.json` 之 type-level isolation,本 feature 加上 bundle-level **第二道防線**。✓
+- **Sensitive material policy**:secret-scan job 用 gitleaks 機械化憲法 §Sensitive material policy 之全部 ban list(`.claude/.credentials.json`、`.env`、`.dev.vars`、`*.pem`、`*.key` 等)。✓
+
+### Development Workflow & Quality Gates — ✅ ENHANCING
+
+本 feature 把以下 gate 從「人工 attest」升「機械化」:
+
+- Tests pass (gate 1) → CI gates job 自動驗
+- Types clean (gate 2) → CI gates job 自動驗
+- Lint clean (gate 3) → CI gates job 自動驗
+- Container parity (gate 4, Node side) → CI gates job 在 dev container 內跑(Ubuntu side mechanized)
+- Spec coverage (gate 5) → advisory job 自動提示(reviewer 保留豁免權)
+- Lockfiles committed (gate 6) → 既有 `pnpm install --frozen-lockfile` 即驗;本 feature 不另加
+
+**唯一 partial**:Container parity 跨平台(Mac M1 ↔ Ubuntu)仍 manual,因本 feature 不含 macOS runner;此 partial 已於 spec.md FR-013 + SC-002 explicit disclose。
+
+### Constitution Check 結論
+
+**所有 5 Core Principles + Variant Amendment + Technology Stack + Workflow Quality Gates 全部 COMPLIANT 或 ENHANCING**。
+**0 violation,0 deviation 需 record 至 Complexity Tracking**。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-ci-workflow/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md        # Phase 1 output (/speckit-plan command) — light scope, see Phase 1
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── contracts/
+│   ├── ci-gates.md            # 3 mandatory + 2 advisory job 之契約
+│   └── dependabot-policy.md   # grouping rule + schedule + commit convention 之契約
+├── checklists/
+│   └── requirements.md  # /speckit-specify 已產出 (13/13 全 pass)
+├── spec.md              # /speckit-specify 已產出
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+.github/                        # 本 feature 主要落地處 (NEW)
+├── workflows/
+│   └── ci.yml                  # 主 workflow:gates + wrangler-bundle-check + secret-scan + 2 advisory job
+└── dependabot.yml              # Dependabot 配置:schedule + grouping + target branch + commit convention
+
+.gitleaks.toml                  # (optional, 視 false positive 出現頻率) gitleaks allowlist
+
+README.md                       # +§「CI status」段 (NEW SECTION,本 feature 加)
+                                #   - GitHub Actions badge URL
+                                #   - 行為簡述 (3 mandatory + 2 advisory + Dependabot)
+                                #   - branch protection 操作指引
+                                #   - 連結至 specs/003-ci-workflow/quickstart.md
+
+# 本 feature 不修改:
+.devcontainer/                  # 複用既有 dev container 定義
+src/                            # 不動
+tests/                          # 不動
+package.json                    # 不動 (本 feature 不引入 npm dep;workflow YAML 之 actions 版本獨立管理)
+pnpm-lock.yaml                  # 不動
+tsconfig*.json                  # 不動
+eslint.config.js                # 不動
+.devcontainer/devcontainer.json # 不動
+wrangler.jsonc                  # 不動 (wrangler-bundle-check 用既有配置 dry-run)
+```
+
+**Structure Decision**: CI configuration-only feature。新增 artifact 集中於 `.github/`(GitHub Actions 標準位置)+ README §;**不動 application source / tests / toolchain config**(per 憲法 V「trivial-isolation」精神 + spec FR-019 toolchain bump 孤立 commit 紀律,本 feature 雖非 toolchain bump,但同樣保持「不混雜 application 變更」)。
+
+`.gitleaks.toml` 為 optional artifact:預設不建立,僅當 gitleaks 跑出 false positive 需 allowlist 時於 isolated PR 內加入。
+
+## Complexity Tracking
+
+> No violations。Constitution Check 全 COMPLIANT 或 ENHANCING,本表保留為空(per template guidance「Fill ONLY if Constitution Check has violations」)。

--- a/specs/003-ci-workflow/quickstart.md
+++ b/specs/003-ci-workflow/quickstart.md
@@ -1,0 +1,377 @@
+# Quickstart: 003-ci-workflow — Adopter walkthrough
+
+**Feature**: `003-ci-workflow`
+**Phase**: 1 (Design output)
+**Date**: 2026-05-03
+**Audience**: Adopter who fork 此 monorepo,要 enable CI workflow + Dependabot;maintainer 要 trigger / cancel / re-run CI runs;reviewer 要看 CI build progress / read failure logs。
+
+---
+
+## §1 Adopter:fork 後 30 秒啟用 CI
+
+### Step 1 — Fork & clone(若還沒)
+
+```bash
+gh repo fork anew7237/claude-superspec-worker --clone --remote
+cd claude-superspec-worker
+```
+
+或在 GitHub UI 點 Fork。
+
+### Step 2 — 確認 CI 自動啟用(無需配置)
+
+Fork 完成後 **GitHub Actions 自動偵測 `.github/workflows/ci.yml`**。在 GitHub repo 頁面點 `Actions` tab,應看到 workflow `CI`(若無 push,顯示「No runs yet」)。
+
+**不需**:
+- ❌ 不需在 GitHub UI 額外 enable workflow
+- ❌ 不需編輯 `.github/workflows/ci.yml`
+- ❌ 不需設置 GitHub Actions secrets(本 workflow 無 secret 依賴)
+
+### Step 3 — 推第一個 commit 觸發 CI
+
+```bash
+echo "" >> README.md
+git add README.md
+git commit -m "trivial: trigger CI for fork verification"
+git push
+```
+
+回 GitHub `Actions` tab,應看到一個 workflow run 啟動;5-15 分鐘內(per SC-001)出綠/紅結果。
+
+### Step 4 — 設 branch protection(必設,1 分鐘)
+
+CI workflow 跑出來後,Required status checks 才可被加入 branch protection 清單。至 `Settings → Branches → Add branch protection rule`:
+
+1. **Branch name pattern**: `main`
+2. ✅ **Require a pull request before merging**(基本 merge gate)
+3. ✅ **Require status checks to pass before merging**
+4. 在 `Required status checks` 搜尋並加入 **3 個 mandatory checks**:
+   - ✅ `gates`
+   - ✅ `wrangler-bundle-check`
+   - ✅ `secret-scan`
+5. ❌ **不要加** advisory checks(`spec-coverage-advisory`、`toolchain-isolation-advisory`)— 它們是提示,加進來會誤擋 PR
+6. (可選)✅ **Require branches to be up to date before merging**(避免 stale main merge)
+7. Save
+
+完成後任何 PR 須 3 mandatory check 全綠才可 merge。
+
+### Step 5 — 確認 Dependabot 已啟用
+
+至 GitHub repo `Settings → Code security and analysis`,應看到:
+- **Dependabot security updates**: Enabled(自動,GitHub-managed)
+- **Dependabot version updates**: 偵測到 `.github/dependabot.yml` 後自動 enable
+
+若未自動 enable,點「Enable」啟用 Dependabot version updates。
+
+下週一(GitHub UTC)即會看到 Dependabot 開 PR(若有 dep 可升)。
+
+---
+
+## §2 Maintainer:CI 操作日常
+
+### 2.1 看 CI build 進度
+
+| 操作 | 怎麼做 |
+|---|---|
+| 看正在跑之 build | GitHub repo → Actions tab → 點 workflow run |
+| 看具體 job 之 step log | 進 workflow run 後點對應 job → 展開 step |
+| 訂閱失敗通知 | GitHub Settings → Notifications → Actions → On for `Only failed workflows` |
+
+### 2.2 重跑(re-run)
+
+| 場景 | 操作 |
+|---|---|
+| 整 workflow 重跑(全 5 job) | workflow run 頁面右上 `Re-run all jobs` |
+| 只重跑失敗的 job | workflow run 頁面右上 `Re-run failed jobs` |
+| 手動觸發(workflow_dispatch) | Actions tab → CI workflow → `Run workflow` 按鈕 → 選 branch |
+
+### 2.3 取消(cancel)
+
+| 場景 | 操作 |
+|---|---|
+| 取消正在跑之 run | workflow run 頁面右上 `Cancel workflow` |
+| 自動取消舊 run | 已內建(per concurrency rule);同 PR 後續 push 會自動取消 in-progress |
+
+### 2.4 download log / artifact
+
+| 操作 | 怎麼做 |
+|---|---|
+| Download 整 job log | workflow run 頁面右上 `⋮` → `Download log archive` |
+| Download artifact(若 job 上傳)| 在 workflow run 頁面底部「Artifacts」段點下載 |
+
+---
+
+## §3 Reviewer:看 PR 之 CI 狀態
+
+### 3.1 PR 頁面之 status check 區塊
+
+每個 PR 底部有「Some checks haven't completed yet」/「All checks have passed」/「Some checks were not successful」之狀態區。展開可看 5 個 check:
+
+| Check name | 性質 | 失敗即阻擋 merge? |
+|---|---|---|
+| `gates` | mandatory | ✅ Yes(branch protection 已設)|
+| `wrangler-bundle-check` | mandatory | ✅ Yes |
+| `secret-scan` | mandatory | ✅ Yes |
+| `spec-coverage-advisory` | advisory | ❌ No(只 comment 提示) |
+| `toolchain-isolation-advisory` | advisory | ❌ No |
+
+### 3.2 看失敗訊息
+
+點 `Details` 進入 GitHub Actions log:
+
+| Job fail | 直接看哪段 log |
+|---|---|
+| `gates` typecheck error | step「inside container: pnpm typecheck」之 stderr 末段(file:line) |
+| `gates` lint error | step 同上之 ESLint output(含 no-restricted-imports 違規) |
+| `gates` test fail | step「pnpm test:node」/「pnpm test:worker」之 vitest output(失敗 test 名 + assertion diff) |
+| `wrangler-bundle-check` 違規 | step「assert bundle clean」之 stderr;含「BUNDLE CONTAINS FORBIDDEN MODULE: <name>」+ grep 命中行 / 「BUNDLE SIZE N bytes」 |
+| `secret-scan` finding | gitleaks-action 在 PR diff line 直接 inline annotation;額外 log 有 redacted finding 列表 |
+
+### 3.3 看 advisory comment
+
+Advisory 觸發即在 PR 內出現 bot comment(non-mandatory):
+
+- **Spec coverage advisory**:當 PR 動 src/ 但無 spec/
+- **Toolchain isolation advisory**:當 PR 同時動 deps + src
+
+Reviewer 在 comment 下回 reply 表態(豁免 / 駁回 / 補 spec / 拆 PR)。Advisory 不會因此停掉,後續 push 仍會重 comment(per `contracts/ci-gates.md` §5.1 idempotency strategy)。
+
+---
+
+## §4 常見場景操作
+
+### 4.1 我的 PR 跑 secret-scan fail,但其實是 false positive
+
+```bash
+# Step 1: 確認真不是 secret(看 finding 之 file + line)
+# 若是合法字串(eg. test fixture 之 fake token),加 .gitleaks.toml allowlist
+cat > .gitleaks.toml <<'EOF'
+[allowlist]
+description = "False positives reviewed in PR #N"
+paths = [
+  '''tests/fixtures/.*\.json''',
+]
+regexes = [
+  '''sk_test_[a-zA-Z0-9]+''',
+]
+EOF
+
+git add .gitleaks.toml
+git commit -m "chore: add .gitleaks.toml allowlist for fixture fake tokens"
+```
+
+CI 會用新 allowlist 重跑 secret-scan;通過即可 merge。但每次加 entry 須在 PR description 說明確實非 secret(per spec edge case)。
+
+### 4.2 我的 PR 跑 wrangler-bundle-check fail,bundle 撐破 100 KiB
+
+兩條路:
+
+#### Path A — 縮 bundle(優先)
+
+```bash
+# 查 bundle 內最大的 dep
+pnpm exec wrangler deploy --dry-run
+ls -lh .wrangler/dryrun/index.js
+# 用 esbuild visualizer 之類工具找肥點
+```
+
+通常踩雷:
+- 誤 import 大 lib(如 lodash whole module 而非 `lodash/fp/get`)
+- 誤含 polyfill / shim
+
+#### Path B — 升 budget(若確實需要)
+
+修 `.github/workflows/ci.yml` 內 wrangler-bundle-check job 之 `BUDGET=$((100 * 1024))` → eg. `$((150 * 1024))`,並在 PR description 說明:
+
+```text
+本 PR 升 Worker bundle budget 100 KiB → 150 KiB:
+- 原因:新增 hono/middleware/jwt(+ 28 KiB)用於 /api/auth route
+- 已驗證:無多餘 dep;esbuild minified gzip 仍在 50 KiB 內
+- 對 SC-005 影響:headroom 從 ~50% 降至 ~33%,仍夠 future feature 使用
+```
+
+走 isolated commit(per spec assumption #8 + 憲法 §Toolchain pinning isolation 精神)— 升 budget 不夾帶其他 src 變更。
+
+### 4.3 Dependabot 開了個 major bump PR,CI fail
+
+```bash
+# 1. checkout PR 至本機
+gh pr checkout <PR-number>
+
+# 2. 進 dev container 跑 4 gate 看失敗 root cause
+# (VS Code Reopen in Container)
+pnpm install --frozen-lockfile
+pnpm typecheck  # 若 tsc 報新版 dep 之 type 變更
+pnpm test:worker  # 若 runtime API 變化
+
+# 3. 兩條路:
+#    (a) 同 PR 修 break:加 commit 修 src/ 配合新版 → push → CI 重跑
+#    (b) close PR + open issue 追蹤:評估後決定何時升
+
+# Path (a):
+# 修 src/ 直到 4 gate 綠
+git add src/
+git commit -m "chore: adapt to <dep> v5 breaking changes"
+git push
+```
+
+> ⚠️ Path (a) 會觸發 toolchain-isolation-advisory(因為同 PR 動 deps + src)。reviewer 看 advisory comment 留 reply 說明「dep upgrade 必然 require src adaptation」即接受。
+
+### 4.4 我想跳過 CI 跑(eg. 純 markdown typo 修)
+
+**不行**,且不該。CI 為 mandatory gate(per spec FR-001~003)。但 advisory 不會 noise:
+
+- 純 doc-only PR(只動 `*.md` / `specs/**` / `.docs/**`)→ advisory job 自動 skip(per FR-009),只 mandatory 跑
+- mandatory 仍跑,但因為沒動 src/,gates 之 4 個 step 跑得很快(typecheck / lint / test 快結束;cache hit 路徑 < 5 min)
+
+### 4.5 我想知道 CI 跑得多快 / 多慢
+
+GitHub repo → Actions tab → 對應 workflow run → 看右上 wall time。
+
+Cache 健康度:
+- `gates` job:cache hit 預期 ≤ 5 min;cache miss 預期 ≤ 15 min
+- `wrangler-bundle-check`:cache hit ≤ 3 min(install + dry-run + grep)
+- `secret-scan`:PR mode ≤ 30 sec;push to main full history scan ≤ 1 min
+
+若顯著超出:
+- 看是不是 cache miss(workflow run 頁面 step 內有「Cache miss」/「Cache hit」字樣)
+- 看是不是 GitHub Actions 排隊(`ubuntu-latest` runner 高峰時可能要等 ~1 min 才開始跑)
+
+---
+
+## §5 Negative test walkthrough(`/speckit-implement` 階段驗證 spec.md 之 acceptance scenarios)
+
+> 此段為 implementation phase 之 acceptance verification 紀錄;maintainer 在 implement 階段照此跑一遍,確認 6 個 spec scenario 皆驗證。
+
+### 5.1 Scenario 1:乾淨 fork 開首個 PR
+
+**操作**:本 003-ci-workflow PR 自身即驗證此 scenario。
+**預期**:本 PR push 後 GitHub Actions 跑 5 job;mandatory 3 個全綠(本 feature 不引入 src 變更,只加 .github/);advisory 不觸發(本 PR 主要動 specs/ + .github/,屬 doc + config 而非 src)。
+**證據**:此 PR 之 GitHub Actions 跑紀錄(merge 後留作 baseline)。
+
+### 5.2 Scenario 2:`import { Pool } from 'pg'` 至 `src/worker/`
+
+**操作**:在本 PR base 上開 negative test branch:
+
+```bash
+git checkout -b negative-test/scenario-2-cross-runtime-import 003-ci-workflow
+echo "import { Pool } from 'pg';" >> src/worker/index.ts
+git commit -am "negative test: add pg import to worker (should fail lint)"
+git push -u origin negative-test/scenario-2-cross-runtime-import
+gh pr create --title "[negative test] cross-runtime import → expect gates fail" --base 003-ci-workflow
+```
+
+**預期**:CI gates job 之 lint step fail,訊息含 `'pg' import is restricted`;mandatory check `gates` 紅叉。
+**證據**:negative test PR 之 GitHub Actions log(截圖或 link 入 implement 階段之 evidence file)。
+**清理**:close PR 不 merge。
+
+### 5.3 Scenario 3:撐破 100 KiB bundle
+
+**操作**:加重 dep:
+
+```bash
+git checkout -b negative-test/scenario-3-bundle-bloat 003-ci-workflow
+# 加大 dep 至 src/worker/(eg. dynamic import 大模組)
+# 範例:加 import "@cloudflare/workers-types/experimental"(若有)或加重複 logic
+pnpm add lodash  # ~70 KiB,加上 worker 既有 ~64 KiB 可能撐破
+echo 'import _ from "lodash"; _.noop();' >> src/worker/index.ts
+git commit -am "negative test: bloat bundle to exceed 100 KiB"
+git push -u origin negative-test/scenario-3-bundle-bloat
+gh pr create --title "[negative test] bundle > 100 KiB → expect bundle-check fail" --base 003-ci-workflow
+```
+
+**預期**:CI wrangler-bundle-check job fail,訊息含 `BUNDLE SIZE N bytes (M KiB) exceeds budget 102400 bytes (100 KiB)`。
+**證據**:同上。
+**清理**:close PR + revert pnpm add。
+
+### 5.4 Scenario 4:fake secret in commit
+
+**操作**:加 known fake secret(用 gitleaks 自身範例 pattern,不洩漏真實 secret):
+
+```bash
+git checkout -b negative-test/scenario-4-fake-secret 003-ci-workflow
+# 用 gitleaks 自身 testdata 內 known-fake fixture pattern (per
+# https://github.com/gitleaks/gitleaks/tree/master/testdata)。
+# Implementation 階段選一可被 gitleaks 預設規則 catch、但確認屬 documentation/test
+# fixture 之示範字串(避免 GitHub Push Protection 也擋)。
+# 例如 fake AWS access key pattern AKIAIOSFODNN7<placeholder> 等;
+# 具體字串於 negative-test PR 內 inline,不寫進 spec doc。
+# echo 'const FAKE_SECRET = "<gitleaks-fixture-pattern>";' >> src/node/temp.ts
+git add src/node/temp.ts
+git commit -m "negative test: add fake stripe key (should fail secret-scan)"
+git push -u origin negative-test/scenario-4-fake-secret
+gh pr create --title "[negative test] fake secret in commit → expect secret-scan fail" --base 003-ci-workflow
+```
+
+**預期**:CI secret-scan job fail,在 PR diff 之 src/node/temp.ts 行出現 gitleaks bot annotation(redacted)。
+**證據**:同上。
+**清理**:close PR。
+
+### 5.5 Scenario 5:src 動但無 spec(advisory)
+
+**操作**:小 src 變更不開 spec:
+
+```bash
+git checkout -b negative-test/scenario-5-src-no-spec 003-ci-workflow
+# 動 src/node/app.ts 加 trivial change
+echo "// trivial change" >> src/node/app.ts
+git commit -am "negative test: src change without spec (should trigger advisory)"
+git push -u origin negative-test/scenario-5-src-no-spec
+gh pr create --title "[negative test] src without spec → expect advisory comment" --base 003-ci-workflow
+```
+
+**預期**:`spec-coverage-advisory` job 在 PR 內 comment 提示;mandatory 仍跑綠(unless 其他原因 fail);PR 可 merge(advisory 不阻擋)。
+**證據**:同上。
+**清理**:close PR。
+
+### 5.6 Scenario 6:同時動 deps + src(advisory)
+
+**操作**:模擬 dep bump 夾帶 src 變更:
+
+```bash
+git checkout -b negative-test/scenario-6-deps-and-src 003-ci-workflow
+# 動 package.json + src/
+pnpm add @types/node@latest  # 動 package.json + pnpm-lock.yaml
+echo "// trivial change" >> src/node/app.ts  # 動 src/
+git add package.json pnpm-lock.yaml src/node/app.ts
+git commit -m "negative test: deps + src in same PR (should trigger advisory)"
+git push -u origin negative-test/scenario-6-deps-and-src
+gh pr create --title "[negative test] deps + src → expect advisory comment" --base 003-ci-workflow
+```
+
+**預期**:`toolchain-isolation-advisory` job comment 提示;mandatory 仍跑;PR 可 merge。
+**證據**:同上。
+**清理**:close PR。
+
+---
+
+## §6 故障排除
+
+| 症狀 | 可能原因 | 解法 |
+|---|---|---|
+| Fork 後推 commit 但 Actions tab 無 run | GitHub Actions 在 fork 端預設 disabled(私有 fork)| Settings → Actions → General → 啟用 |
+| `gates` job 跑得超慢(> 15 min) | Cache miss + dev container cold build | 第二次跑應快(image cache 入 GHCR);若一直 cache miss,看 `pnpm-lock.yaml` 是否頻繁變動 |
+| `secret-scan` 在 push to main 跑超慢(> 5 min) | git history 太大(> 10k commits)| 評估改用 PR-only mode 或 partial history(per spec edge case) |
+| `wrangler-bundle-check` 跑 dry-run 失敗 | wrangler.jsonc 配置錯 / Worker code typecheck error | 先在本機跑 `pnpm exec wrangler deploy --dry-run` 確認本機可 build |
+| Dependabot 不開 PR | 本週無可升的 dep / open PR limit 已滿 / Dependabot service outage | 看 Insights → Dependency graph → Dependabot tab 之 alert 訊息 |
+| Advisory comment 出現太多次 | 每次 push 都重 comment(per design,per research §6) | 接受此設計;若噪音真大,follow-up 改用 marker idempotent comment |
+
+---
+
+## §7 升級 / 維運
+
+### 7.1 升級 GitHub Actions 版本
+
+由 Dependabot `github-actions` ecosystem entry 自動掃週(per `contracts/dependabot-policy.md` §3)。Maintainer 看 PR 跑綠即 merge。
+
+### 7.2 升級 dev container image
+
+不在本 feature 範圍。修 `.devcontainer/Dockerfile` / `devcontainer.json` 即生效;CI 自動跟進(因為用 `devcontainers/ci@v0.3` 動態 build);對齊 plan §Constitution Check III。
+
+### 7.3 升級 bundle budget
+
+per §4.2 Path B,走 isolated commit + reviewer 認可。
+
+### 7.4 加 / 改 Dependabot grouping rule
+
+走 isolated commit(per `contracts/dependabot-policy.md` §5 不變量);PR description 說明為何加 / 改 group。

--- a/specs/003-ci-workflow/research.md
+++ b/specs/003-ci-workflow/research.md
@@ -1,0 +1,567 @@
+# Research: 003-ci-workflow — 技術選擇與決策日誌
+
+**Feature**: `003-ci-workflow`
+**Phase**: 0 (Research, before Phase 1 contracts/data-model/quickstart)
+**Date**: 2026-05-03
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+本檔記錄 plan.md Constitution Check 階段識別之技術選擇與「best practices」研究結論。Plan 階段所有 NEEDS CLARIFICATION 已於 spec.md §Clarifications 解決(6 個 Q/A 預先回答,無未解項);本檔聚焦 plan 階段引入之**技術 anchor 選擇**(Marketplace action 版本、cache 策略、grouping pattern、advisory comment 機制等)。
+
+---
+
+## §1 Dev container in CI:`devcontainers/ci@v0.3` action vs 手動 docker build
+
+### Decision: `devcontainers/ci@v0.3`(GitHub Marketplace 官方 action)
+
+### Rationale
+
+對齊憲法 III「CI MUST execute on the same base image as the dev container」之 spec-strict 解讀(per spec.md Q1 Clarification),本 feature 必須以 `.devcontainer/` 內定義之 image 跑 4 gates。兩條技術路徑:
+
+**Path A — `devcontainers/ci@v0.3` 官方 action**:
+
+- ✅ 由 Microsoft / Dev Containers spec 維護(`https://github.com/devcontainers/ci`),GitHub Marketplace 主流選擇
+- ✅ 自動讀 `.devcontainer/devcontainer.json` + `Dockerfile`,build + cache + run 全包
+- ✅ 內建 GHCR(GitHub Container Registry)cache layer,後續跑直接命中 image cache
+- ✅ Adopter fork 後自動跟進(若 fork 改 `.devcontainer/`,CI 自動 rebuild)
+- ⚠ 額外 dependency on Marketplace action(屬 toolchain pin,per 憲法 §Toolchain pinning)
+- 📦 拉新 image 之首次 build 預期 ~10 min;cached run ~1 min(per Edge Cases prediction)
+
+**Path B — 手動 `docker build .devcontainer/` + `docker run`**:
+
+- ⚠ 需自寫 build / cache / run 三段 step,維護成本高
+- ⚠ Cache 策略需自己組(actions/cache + docker layer cache);失敗模式多
+- ✅ 不依賴 Marketplace action(supply-chain 風險低 ~ε)
+- ⚠ 與 dev container spec 之 `postCreateCommand` / `features` 解析不對齊(devcontainers/ci 自動處理;手動 docker run 需自行 replicate)
+
+**選 A 之關鍵理由**:`devcontainers/ci` 是業界標準解,supply-chain 風險已由 Microsoft 維護;手動 docker run 重做已解問題,違反 SE 最小驚奇原則。Toolchain pinning 規範保證升版可單獨 revert(@v0.3 鎖 minor;升 v0.4 走 isolated commit)。
+
+### Alternatives considered
+
+- ❌ **`devcontainer-cli` + 手動 wrap**:屬 Path B 變體;同樣維護負擔,且 `devcontainer-cli` 為 npm tool 增加 install 步驟
+- ❌ **不用 dev container,直接 `pnpm/action-setup` + Node 22**:違反 spec FR-004 + 憲法 III「same base image」契約,屬 spec-strict violation
+
+---
+
+## §2 Secret-scan tool 與版本:`gitleaks/gitleaks-action@v2`
+
+### Decision: `gitleaks/gitleaks-action@v2`(Marketplace 官方 action)
+
+### Rationale
+
+per spec.md Q3 Clarification 已選 gitleaks(open-source、GitHub Actions 維護良好、預設規則覆蓋 OAuth tokens / API keys / `.env` 內容 / certificate 等)。版本選擇 @v2(當前 latest)。
+
+**為何不選其他工具**:
+
+- ❌ **truffleHog**:預設掃更廣(verified secrets 之 active validation),但 PR diff 模式有時誤判導致 noise;OSS starter 不需 enterprise-grade scanning
+- ❌ **GitHub Secret Scanning(內建)**:免費版只掃 GitHub-recognized partner secrets(eg. AWS / Stripe);不掃 Anthropic OAuth / 自定義 secret pattern;且只在 push 後 detect,不在 PR diff 階段 block
+
+**為何選 gitleaks @v2**:
+
+- ✅ Marketplace 主流(`https://github.com/gitleaks/gitleaks-action`)
+- ✅ 預設規則含 generic API key + `.env` style + private key file 等通用 pattern
+- ✅ 支援 `.gitleaks.toml` 在 repo root 設 allowlist(per spec edge case)
+- ✅ PR 模式自動掃 PR diff;push 模式可掃 N commits(本 feature 在 main push 設掃全 history,per spec.md US1 Acceptance #5)
+- ✅ Action 版本 @v2 為當前 latest stable,無 breaking change in active maintenance
+
+### Alternatives considered
+
+- ❌ truffleHog v3:更深掃但更多 false positive;OSS 入門級不需要
+- ❌ GitHub Advanced Security(secret scanning):enterprise paid 功能,違反 monorepo「fork-friendly free tier」承諾
+- ❌ 自寫 grep-based scan:重做 gitleaks 已解,且 ad-hoc regex 易漏
+
+### Configuration notes
+
+- 預設掃描範圍:PR diff(PR trigger)/ 全 history(push to main trigger)
+- License key:gitleaks-action v2 預設 OSS-friendly 模式可免費跑;不需 commercial license(per Action README)
+- Output format:GitHub Actions annotations(直接在 PR diff line 標 finding)
+- 失敗訊息:redacted secret value + 只列 file + line(per spec FR-011)
+
+---
+
+## §3 Cache 策略:pnpm store + node_modules 雙層 + 可選 TS incremental
+
+### Decision: `actions/cache@v4` 雙層 cache,key 雙錨
+
+### Rationale
+
+`pnpm install --frozen-lockfile` 在 cold cache 下需拉 ~500 packages 含 wrangler/workerd binaries(per session memory:WSL2 host 跑 ~22s,WSL2 dev container cold ~8min),CI 需 cache 才能符合 SC-001(cache hit ≤ 5 min)。
+
+**Cache 策略**:
+
+```yaml
+- name: Cache pnpm store
+  uses: actions/cache@v4
+  with:
+    path: ~/.local/share/pnpm/store
+    key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+    restore-keys: pnpm-store-${{ runner.os }}-
+
+- name: Cache node_modules
+  uses: actions/cache@v4
+  with:
+    path: node_modules
+    key: node_modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+    restore-keys: node_modules-${{ runner.os }}-
+```
+
+雙層 cache 理由:
+
+- pnpm store 是全域 package CAS;命中即跳過 npm registry HTTP roundtrip
+- node_modules 是 project-local symlink tree;命中即跳過 pnpm install 之 link 階段
+- 兩層分開的好處:lockfile 微改時 store 仍命中(只需 link 新版),整體更快
+
+**Restore keys**:fall-back 到 `pnpm-store-${{ runner.os }}-`(無 hash suffix)即「同 OS 任 lockfile hash」之最近 cache;命中 partial 仍比 cold 快 ~3x。
+
+**TS incremental cache(可選)**:
+
+```yaml
+- name: Cache TypeScript incremental build
+  uses: actions/cache@v4
+  with:
+    path: |
+      .tsbuildinfo
+      tests/**/.tsbuildinfo
+    key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('tsconfig*.json', 'src/**', 'tests/**') }}
+```
+
+TS incremental 能讓 typecheck 從 ~30s 降到 ~5s,但 cache key invalidation 需含 src/tests 全 hash → cache 命中率低;**初版不啟用**,SC-001 cache hit 已能滿足 ≤ 5 min budget。若實際跑後 typecheck 為 bottleneck,follow-up PR 啟用。
+
+### Alternatives considered
+
+- ❌ 單層只 cache pnpm store:lockfile 改後 link 階段仍慢,影響 cache hit budget
+- ❌ 完全不 cache:CI 每次跑 install 8+ min,違反 SC-001
+- ❌ Docker layer cache(GHCR push):屬 Path A `devcontainers/ci@v0.3` 內建,本層 cache 是 dev container image 之 layer;與 npm-level cache 互補
+
+---
+
+## §4 Wrangler bundle check 機制:`wrangler deploy --dry-run` + grep + size assertion
+
+### Decision: 用 `wrangler deploy --dry-run` 產生 bundle,然後在 shell 內 grep + `wc -c`
+
+### Rationale
+
+Wrangler v4(本 feature 已 land per PR #20)`deploy --dry-run` 產生 `.wrangler/dryrun/index.js` 含完整 bundle(post esbuild + minification before publish to Cloudflare)。本 feature 取此 file 直接驗:
+
+```bash
+# 1. Run dry-run
+pnpm exec wrangler deploy --dry-run
+
+# 2. Grep for forbidden Node-only modules
+BUNDLE=.wrangler/dryrun/index.js
+FORBIDDEN=("pg" "redis" "pino" "prom-client" "@hono/node-server" "node:fs" "node:child_process")
+for mod in "${FORBIDDEN[@]}"; do
+  if grep -q "$mod" "$BUNDLE"; then
+    echo "❌ BUNDLE CONTAINS FORBIDDEN MODULE: $mod"
+    grep -n "$mod" "$BUNDLE" | head -5
+    exit 1
+  fi
+done
+
+# 3. Size assertion
+SIZE=$(wc -c < "$BUNDLE")
+BUDGET=$((100 * 1024))  # 100 KiB
+if [ "$SIZE" -gt "$BUDGET" ]; then
+  echo "❌ BUNDLE SIZE $SIZE bytes exceeds budget $BUDGET bytes"
+  exit 1
+fi
+echo "✅ bundle clean: $SIZE bytes (budget $BUDGET)"
+```
+
+**為何不用 wrangler-internal flag**:wrangler 沒提供「禁用某 dep」之內建 flag;esbuild 端可加 `external` rule,但已被 wrangler internal config 控制,不易 override。Grep 為**最小可行第二道防線**,不依賴 wrangler 內部行為。
+
+**為何在 shell 而非 npm script**:CI job 之 step 直接寫 inline shell 較易 debug;若未來 promote 至 npm script(eg. `pnpm bundle:check`),屬 follow-up refactor。
+
+### Alternatives considered
+
+- ❌ AST-based parser:過度複雜;esbuild minified bundle 仍含可 grep 之 module specifier
+- ❌ 用 `bundlephobia` API:外部 service 不該成為 CI 依賴
+- ❌ 跑 `webpack-bundle-analyzer`:對 Cloudflare Workers bundle 不適配
+- ❌ 比較 deploy 後 actual size from Cloudflare:打 production API,違反 FR-010
+
+### Bundle size budget 起點:100 KiB
+
+per spec.md Q2 Clarification + 當前實測 ~64 KiB(per session memory PR #17 sanity check:"bundle 64.70 KiB / gzip: 15.94 KiB")。100 KiB 留 ~50% headroom,允許 adopter 加少量 routes / utils 不撐破。Adopter 自家 feature 撐破 budget 在 isolated commit 內升 budget(per spec edge case + 憲法 §Toolchain pinning isolation 精神)。
+
+---
+
+## §5 Dependabot grouping pattern
+
+### Decision: 按 ecosystem family 分組,major 各自獨立 PR
+
+### Rationale
+
+per spec.md FR-007 已鎖定 5 條 grouping rule:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      cloudflare-ecosystem:
+        patterns:
+          - "@cloudflare/*"
+          - "wrangler"
+          - "miniflare"
+        update-types: ["minor", "patch"]
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+        update-types: ["minor", "patch"]
+      vitest:
+        patterns:
+          - "@vitest/*"
+          - "vitest"
+        update-types: ["minor", "patch"]
+      node-deps-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@cloudflare/*"
+          - "wrangler"
+          - "miniflare"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+          - "@vitest/*"
+          - "vitest"
+        update-types: ["minor", "patch"]
+      # major bumps: not grouped, 各自 PR (default Dependabot behavior)
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types: ["minor", "patch"]
+```
+
+**理由**:
+
+- `@cloudflare/*` 同組 — issue #15 root-cause 已驗:wrangler 與 vitest-pool-workers 之 transitive workerd 須對齊,分開升易 dedupe drift
+- `@typescript-eslint/*` 同組 — eslint plugin 與 parser 須對齊
+- `@vitest/*` 同組 — vitest core / runner / spy 須對齊
+- 其他 minor + patch 一組 — 減少 PR 噪音
+- **Major 各自獨立 PR**(Dependabot 預設不對 major 應用 grouping,自動分 PR)— 避免 breaking change 被 grouping 遮蔽
+- `package-ecosystem: github-actions` 同步監控 GitHub Actions 升版(per Plan §Technology Stack「Toolchain pinning isolation」)
+
+### Alternatives considered
+
+- ❌ 不分組(每 dep 一 PR):每週 PR 數爆炸,maintainer noise 高
+- ❌ 一組 catch-all:major 與 minor 混升,看不清 breaking change scope
+- ❌ Renovate(替代 Dependabot):per spec assumption #5,不打包 Renovate;adopter customization 屬 derivative concern
+
+---
+
+## §6 Advisory job 之 GitHub PR comment 機制
+
+### Decision: `actions/github-script@v7` + `gh issue comment`(via GH CLI)二擇一,初版用 `actions/github-script`
+
+### Rationale
+
+Advisory job 需在 PR 內 comment 提示 reviewer。兩條技術路徑:
+
+**Path A — `actions/github-script@v7`**:
+
+- ✅ 官方 action,內建 `octokit/rest.js` client + GitHub token 自動注入
+- ✅ TypeScript-style snippet 易讀;能直接 query PR diff API + post comment
+- ✅ 不需 install 額外 CLI
+
+```yaml
+- uses: actions/github-script@v7
+  with:
+    script: |
+      const { data: files } = await github.rest.pulls.listFiles({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.issue.number,
+      });
+      const srcChanges = files.some(f => f.filename.startsWith('src/'));
+      const specChanges = files.some(f => f.filename.startsWith('specs/'));
+      if (srcChanges && !specChanges) {
+        await github.rest.issues.createComment({
+          ...
+          body: '⚠ Advisory: src/ changed without matching specs/NNN-*/ ...',
+        });
+      }
+```
+
+**Path B — `gh issue comment` via GH CLI**:
+
+- ⚠ 需 install gh CLI(可用 ubuntu-latest 內建)
+- ⚠ Shell-only,query PR file list 需多步 jq parse
+- ✅ 較不依賴 octokit 版本
+
+**選 A 之理由**:本 feature 已用 Marketplace action 全套(actions/checkout、cache、devcontainers/ci、gitleaks),再加 actions/github-script 屬同類;snippet 可直接寫 inline,不需獨立 script file。Path B 維護成本高(JSON parse + 多步 shell)。
+
+### Comment idempotency strategy
+
+Advisory comment **不去重**(per spec.md US4 #4):每次 PR 觸發即重 comment。理由:
+
+- Reviewer 看每次 push 即知狀態(無 stale comment 問題)
+- `actions/github-script` 內如果要去重需 query 既有 comment + diff,複雜度上升
+- PR 收尾時 reviewer 可手動 hide outdated comment
+
+若未來 reviewer 反映 noise 過多,可用 `peter-evans/create-or-update-comment` action 加 marker(eg. `<!-- ADVISORY:spec-coverage -->`)實作 update-in-place,屬 follow-up。
+
+### Alternatives considered
+
+- ❌ 把 advisory 升為 mandatory(fail PR):違反 spec FR-008「不阻擋 merge」設計;reviewer 失去豁免權
+- ❌ 用 GitHub Check API 而非 PR comment:check 不會 inline 顯示 reasoning,reviewer 易忽略
+- ❌ 寫獨立 npm tool(eg. `pnpm spec-coverage-check`):過度工程化;CI 限定的 advisory 不需獨立 tool
+
+---
+
+## §7 Triggers 與 concurrency 控制
+
+### Decision: 三條 trigger + concurrency group 自動取消舊跑
+
+### Rationale
+
+per spec.md FR-002,觸發條件涵蓋:
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+**Concurrency rule 理由**:
+
+- 同一 PR 連續 push 時,只跑最新 commit(取消 in-progress);省 GitHub Actions minutes
+- 不影響 main push 與 PR 之間的隔離(group key 含 ref,PR 與 main 各自一組)
+- adopter fork 後行為一致(無需額外配置)
+
+### Alternatives considered
+
+- ❌ 不設 concurrency:同 PR 多次 push 並行跑 4 個 instance,浪費 minutes
+- ❌ 用 schedule trigger(eg. nightly):本 feature 之 mandatory check 性質為 PR-time,不需 nightly redundant 跑
+
+---
+
+## §8 失敗訊息設計(對齊 spec FR-011)
+
+### Decision: 各 job 用 `set -euo pipefail` + 末段 stderr 顯式 echo
+
+### Rationale
+
+GitHub Actions 預設展示 step output,但長 stderr 可能淹沒關鍵訊息。本 feature 加 `tail -50` style summary at job end:
+
+- **gates job**:vitest / tsc / eslint 自帶 colored output;CI 端設 `FORCE_COLOR=1` 保留色彩
+- **wrangler-bundle-check job**:fail 時直接 `echo` grep 命中行 + bundle size 數字
+- **secret-scan job**:gitleaks-action @v2 預設 redact secret value,只報 file + line(符合 FR-011)
+
+**`set -euo pipefail`**:
+
+- `-e` 任一 step fail 即整 step fail
+- `-u` undefined var 即 fail(防 typo)
+- `-o pipefail` pipe 內任一 segment fail 即整 pipe fail(否則 `tail` 會吃掉前面的 exit code)
+
+### Alternatives considered
+
+- ❌ 不設 `pipefail`:`pnpm test:worker | tee log` 失敗會 silent pass(tee 成功 → exit 0)
+- ❌ 改用 `actions/upload-artifact` 收 log file:增加 step + 不解決「PR 頁面直接看 reasoning」需求
+
+---
+
+## §9 GitHub Actions runner OS pin
+
+### Decision: `runs-on: ubuntu-latest`(GitHub-hosted)
+
+### Rationale
+
+per spec assumption #2 + Q6 Clarification(no macOS),adopter 用 GitHub-hosted runner 即可。`ubuntu-latest` 自動跟進 Ubuntu LTS(目前 24.04),與 dev container base image(Ubuntu 24.04)同源。
+
+**為何不 pin 到 `ubuntu-24.04`**:
+
+- 鎖死 minor 反而限制升級彈性;`-latest` 由 GitHub 維護升級節奏
+- Adopter 若需 self-hosted runner(per assumption #2),可在 fork 端改 `runs-on: self-hosted`
+
+**為何不額外 matrix(eg. Node 22 + Node 24)**:
+
+- 本 feature gates job 在 dev container 內跑;Node 版本由 dev container `Dockerfile` / `devcontainer.json` 定義(Node 22),不由 host runner 控制
+- Matrix 多版本屬 future feature(若 dev container 升 Node 24 / 26 時要驗 backward compat)
+
+### Alternatives considered
+
+- ❌ pin `ubuntu-22.04`:LTS 即將 EOL(預期 2027);無 future-proof 收益
+- ❌ matrix on Node version:本 feature dev container in CI,Node 由 image 控制,matrix 無意義
+
+---
+
+## §10 Branch protection 設定指引(在 README + PR description)
+
+### Decision: 不在本 feature workflow 內自動設;在 README + PR description 寫操作指引
+
+### Rationale
+
+per spec assumption #6 + Out-of-scope table:branch protection 屬 GitHub repo settings(非 workflow YAML),由 adopter 在 GitHub UI 手動設或用 Terraform/`gh api` 自動化。本 feature 不打包此自動化(否則需 admin token + 跨 repo 假設)。
+
+**指引內容**(將寫入 README §「CI status」+ 本 feature PR description):
+
+```text
+本 feature merge 後請至 Settings → Branches → Add branch protection rule for `main`:
+- ✅ Require a pull request before merging
+- ✅ Require status checks to pass before merging
+- 在 Required status checks list 加入:
+    - gates
+    - wrangler-bundle-check
+    - secret-scan
+- 不需要加:spec-coverage-advisory / toolchain-isolation-advisory(屬 advisory)
+```
+
+### Alternatives considered
+
+- ❌ Terraform module / `gh api` script in CI:需 admin token 跨 repo 風險;OSS adopter 不一定有 admin
+- ❌ Default ON via repo template:不存在此 GitHub feature
+- ❌ workflow_dispatch + `gh api`:仍需 admin token,且 admin token 不會自動 forward 給 fork
+
+---
+
+## §11 Conditional advisory trigger(排除 doc-only PR)
+
+### Decision: 在 advisory job 之 step 內用 `actions/github-script` 自行判斷,而非用 `paths`/`paths-ignore` filter
+
+### Rationale
+
+per spec FR-009,advisory job 須排除 doc-only PR(動 `specs/**`、`.docs/**`、`*.md` 而未動 `src/**` `tests/**` `package.json` `pnpm-lock.yaml`)。
+
+**為何不用 `paths-ignore`**:
+
+- workflow YAML 之 `paths-ignore` 是「整個 workflow trigger 之 filter」,會連 mandatory job 都不跑
+- 本 feature mandatory check 須**所有 PR 都跑**(per spec FR-001),只 advisory 排除 doc-only
+
+**改用 step-level 條件**:
+
+```yaml
+- name: Check if doc-only PR
+  id: doc_check
+  uses: actions/github-script@v7
+  with:
+    script: |
+      const { data: files } = await github.rest.pulls.listFiles({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.issue.number,
+      });
+      const isDocOnly = files.every(f =>
+        f.filename.startsWith('specs/') ||
+        f.filename.startsWith('.docs/') ||
+        f.filename.endsWith('.md')
+      );
+      core.setOutput('doc_only', isDocOnly);
+
+- name: SC-003 spec coverage advisory
+  if: steps.doc_check.outputs.doc_only != 'true'
+  uses: actions/github-script@v7
+  with:
+    script: |
+      // ... post comment if src/ touched but specs/ not
+```
+
+### Alternatives considered
+
+- ❌ 用 `paths` filter at workflow level:會跳過 mandatory job
+- ❌ 把 advisory 移到 separate workflow file:複雜度上升;不解決「mandatory 須跑」問題
+
+---
+
+## §12 GitHub Actions versions pinning policy
+
+### Decision: 鎖 minor(`@v4` not `@v4.2.0`,but not `@v4.x`)
+
+### Rationale
+
+GitHub Actions Marketplace action 之 version tag 慣例:
+
+- `@v4` = 鎖 major(內含 v4.0.0 ~ v4.99.x);Marketplace 維護者承諾 v4 內無 breaking
+- `@v4.2.0` = 鎖 patch(supply-chain 最嚴);但每個 patch 升版需手動跟
+- `@main` / `@master` = 不鎖(極不安全)
+
+**選擇 `@v4` 鎖 major**:
+
+- 平衡安全性與維護成本
+- Dependabot 之 `package-ecosystem: github-actions` 自動掃 major 升版(eg. v4 → v5)並開 PR;maintainer 看 CI 跑綠即知是否 break
+- 對齊 npm dep 之 `^4.0.0` 慣例(major 鎖,minor + patch 自動跟)
+
+**例外**(若某 action 已知 minor 內有 regression):
+
+- 鎖 `@v4.2.0`(patch);列入 `.specify/notes/`(future)或 PR description 說明
+
+### Alternatives considered
+
+- ❌ 鎖 SHA(`@a1b2c3d4`):supply-chain 最嚴但每次升版手動;不適合 OSS starter scale
+- ❌ `@latest`:無此 GitHub-recognized tag;且無語義保證
+- ❌ 不鎖:`@main` 風險高(maintainer 推 breaking 即 break adopter)
+
+---
+
+## §13 工具鏈版本 anchor 一覽(本 feature 引入)
+
+| Tool / Action | Pin | Source |
+|---|---|---|
+| `actions/checkout` | `@v4` | GitHub official |
+| `pnpm/action-setup` | `@v4` | pnpm official |
+| `actions/cache` | `@v4` | GitHub official |
+| `actions/github-script` | `@v7` | GitHub official |
+| `devcontainers/ci` | `@v0.3` | Microsoft / Dev Containers spec |
+| `gitleaks/gitleaks-action` | `@v2` | gitleaks official |
+
+**升版規則**:per 憲法 §Toolchain pinning + spec FR-019,任一上表 action 升 major(eg. `@v4` → `@v5`)走 isolated commit;Dependabot 自動開 PR,CI 跑綠即可 merge。
+
+---
+
+## §14 與既有 baseline 之 anchor 對齊
+
+本 feature 之每條 FR / SC 對應 baseline anchor:
+
+| 003 FR / SC | 對應 anchor |
+|---|---|
+| FR-001 / FR-002 / FR-003 | 001 baseline FR-017 + quality-gates.md §「CI 對應(known gap)」 |
+| FR-004 | 001 憲法 III「same base image」+ research.md Critical Follow-up #1 |
+| FR-005 | 002 spec assumption #6(toolchain pin)+ session memory「workerd cold install ~8 min」 |
+| FR-006 / FR-007 | 001 FR-019(toolchain isolated commit)+ 002 spec dependencies cite |
+| FR-008(advisory)| 001 SC-003 + FR-019 之機械化前哨 |
+| FR-009 | 001 quality-gates.md「人工豁免規則」 |
+| FR-010 | 001 sensitive-material.md §「DevContainer mount 規範」 |
+| FR-011 | 001 observability.md §1.4(failure 訊息設計精神) |
+| FR-012 | 002 README §「Dual-Runtime」+ 既有 README structure |
+| FR-013 | reviewer audit I-1 PARTIAL + .docs/baseline-traceability-matrix.md FR-017/SC-005/SC-006/SC-008 row |
+| SC-001~011 | 對應 spec.md §「Spec impact」表;driver SC 為 baseline 規則之機械化升級 |
+
+---
+
+## 結論與下一步
+
+Phase 0 research 完成,所有技術選擇 anchor 已記錄。**0 NEEDS CLARIFICATION 殘留**。
+
+下一步 Phase 1:
+- `data-model.md`:本 feature scope 屬 light(無 application data model);記錄 CI workflow 之 entity 結構 + 與 spec.md §Key Entities 對齊
+- `contracts/ci-gates.md`:3 mandatory + 2 advisory job 之契約(input / output / failure mode / observable behavior)
+- `contracts/dependabot-policy.md`:grouping rule + schedule + commit convention 之契約
+- `quickstart.md`:adopter 看 CI build / 重跑 / cancel + branch protection 設定 walkthrough
+- 更新 `CLAUDE.md` SPECKIT 區塊指向本 plan

--- a/specs/003-ci-workflow/spec.md
+++ b/specs/003-ci-workflow/spec.md
@@ -1,0 +1,193 @@
+# Feature Specification: CI Workflow + Dependabot — Ubuntu Mechanization of Baseline Gates
+
+**Feature Branch**: `003-ci-workflow`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: User description: "003-ci-workflow — Ubuntu-only CI workflow + dependabot,機械化現有 baseline 之 FR-017 (CI ↔ dev container same base image) + SC-005 (toolchain revert success rate) + SC-006 (zero OAuth credentials in git history) + 002 FR-009 / SC-003 (Worker bundle 不含 Node-only modules)"
+
+> **設計來源**:reviewer audit(PR #16 / #19 留下的 I-1 PARTIAL)— 001 FR-017 CI gap 為 audit 唯一未閉合項;`specs/001-superspec-baseline/contracts/quality-gates.md` §「CI 對應(known gap)」+ `research.md` Critical Follow-up #1。
+>
+> **Baseline anchor**:002-cloudflare-worker 已落地之 4 mandatory gates(`pnpm test:node` / `pnpm test:worker` / `pnpm typecheck` / `pnpm lint`)當前由人類於本機 dev container 執行;本 feature 把同樣 4 gates 升至 CI 自動執行,並新增 wrangler bundle 純度檢查 + secret scan + dependency 升版自動化 + 兩條 advisory 提示。
+>
+> **Single-platform 限制**:本 feature 僅機械化 Ubuntu side(per adopter 偏好 + macOS Actions minutes 成本考量);跨 Mac/WSL2 parity(SC-002)仍走 `.docs/parity-validation.md` 人工流程。
+
+## Clarifications
+
+### Session 2026-05-03
+
+- Q: CI 內跑 4 gates 之執行環境? → A: **dev container in CI**(per FR-017 spec-strict 解讀;不是「Node 22 + pnpm 9 host install」近似)。CI 必須以 `.devcontainer/` 內定義之 image 跑 gates,確保 CI 行為與本機 dev container 100% 對齊。
+- Q: Worker bundle size budget threshold? → A: **100 KiB**(當前 ~64 KiB,留 ~50% headroom;超出即 mandatory fail。Adopter 隨自家 feature 加大 bundle 後,可在 isolated commit 內升 budget,須經 reviewer 認可)。
+- Q: Secret-scan tool 選擇? → A: **gitleaks**(open-source,GitHub Actions 維護良好;PR 觸發掃 PR diff,push to main 觸發掃全 git history)。
+- Q: SC-003 spec coverage advisory job 是否落地? → A: **Yes**(advisory 提示,不阻擋 merge;reviewer 可 PR comment 內豁免)。
+- Q: FR-019 toolchain isolation advisory job 是否落地? → A: **Yes**(advisory 提示,不阻擋 merge)。
+- Q: CI 是否含 macOS runner? → A: **No**(adopter 偏好 + Actions minutes 成本;SC-002 跨平台 parity 仍走人工 `.docs/parity-validation.md` 流程)。
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - 新進開發者第一次開 PR 即看見自動 gate 跑綠 (Priority: P1) 🎯 MVP
+
+一位剛 onboard 的開發者在自家 feature branch 上推第一個 commit、開 PR 至 main。他無需手動進 dev container 跑 4 gates,GitHub PR 頁面在 5-10 分鐘內出現 3 個 mandatory check 結果(gates / wrangler-bundle-check / secret-scan)。若全綠,reviewer 可放心 review code 不必擔心「在我機器上會綠」;若紅,error 訊息直指違規(typecheck error / test fail / bundle 含 Node-only module / git 內含 secret 等)。
+
+**Why this priority**:此為本 feature 之核心兌現價值。失去自動 gate,新人 PR 仍須靠口耳相傳「請先進 dev container 跑 4 gate」,baseline FR-017 仍為 known gap,reviewer 仍須人工 attest 各 SC 滿足度。MVP 只需 gates + wrangler-bundle-check + secret-scan 3 個 mandatory 即達成 P1 兌現。
+
+**Independent Test**:乾淨 fork 後開 trivial PR(eg. typo fix),PR 頁面出現 3 mandatory check 自動跑,5-10 分內看到綠/紅結果;reviewer 不需問開發者「有沒有跑過 4 gate」即可判定 mergeability。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一個乾淨 fork + clone,**When** adopter 開第一個 PR 至 main,**Then** GitHub PR 頁面出現 3 mandatory check(gates / wrangler-bundle-check / secret-scan)自動跑,在 ≤ 10 分內出結果。
+2. **Given** PR 動到 `src/worker/index.ts` 加 `import { Pool } from 'pg'`,**When** CI 跑完,**Then** gates job 之 lint 步驟 fail(per 既有 `eslint.config.js` `no-restricted-imports` rule;FR-022 機械化),整 job exit 非 0,PR 標 mandatory check failure。
+3. **Given** PR 引入 dep 把 wrangler bundle 撐到 > 100 KiB,**When** CI 跑完,**Then** wrangler-bundle-check job fail,error 訊息指出 bundle size 超出 threshold + 當前實際大小。
+4. **Given** PR commit 內含 `password=secret123` 之文字 / 真實看似 OAuth token / `.env` 內容,**When** CI 跑完,**Then** secret-scan job fail,gitleaks 指出 finding 與位置。
+5. **Given** PR merge 後 push to main,**When** CI 跑 push trigger,**Then** secret-scan 改掃**全 git history**(非僅 PR diff),確保歷史未洩漏。
+
+---
+
+### User Story 2 - Maintainer 自動收到 Dependabot 升版 PR 並由 CI 驗證 (Priority: P2)
+
+一位 maintainer 不必每週手動 `pnpm outdated` 對照升版。Dependabot 每週一掃 npm 依賴,把可升的版本自動開 PR(per grouping rule);CI 跑完即知是否 break 既有 4 gate,無破即可 merge,有破即可在 PR 內 root-cause、決定 (a) 維持原版 (b) 部分升版 (c) 同 PR 修 break。grouping rule 確保 `@cloudflare/*` 等相關 deps 同 PR 升,避免「a 升 b 沒升」的中間狀態。
+
+**Why this priority**:支撐 baseline FR-019(toolchain 升版為孤立 commit)從「人工提醒」升「自動週期 + 機械驗證」。失去 Dependabot,toolchain 升版易拖延,直到 security advisory 才被動處理。但相較 P1 之 PR-time gate,Dependabot 為「定期維運」型功能,P2。
+
+**Independent Test**:在 main 上故意停留某 dep 之舊版,等下週一 Dependabot 觸發,確認對應 PR 開出且 CI 跑綠;merge 該 PR,確認 lockfile 升版且 4 gate 仍綠。
+
+**Acceptance Scenarios**:
+
+1. **Given** Dependabot 配置就位,**When** 每週一 09:00 UTC,**Then** Dependabot 掃 npm 依賴,把可升的 dep 按 grouping rule 開 PR(每組一條 PR;最多 5 個 open PR)。
+2. **Given** Dependabot 開出之 PR(eg. 升 `@cloudflare/vitest-pool-workers` 0.15.2 → 0.16),**When** PR 開啟,**Then** 既有 3 mandatory check 自動跑(同 P1);全綠即可 merge。
+3. **Given** Dependabot grouping rule 配置含 `@cloudflare/*`,**When** 某週 `wrangler` 與 `@cloudflare/workers-types` 同時有可升,**Then** 兩者同一 PR 內升版,而非分兩 PR。
+4. **Given** Dependabot 開出之 commit message,**When** 看 git log,**Then** 訊息符合既有 `chore(deps): bump xxx` convention(per 001 FR-019)。
+
+---
+
+### User Story 3 - Adopter fork 後 CI 自帶不需 reconfigure (Priority: P2)
+
+一位 adopter clone monorepo 後 fork 到自己的 GitHub org/repo,推第一個 commit 至自家 main(或開 PR)。GitHub Actions 自動偵測 `.github/workflows/ci.yml` 並啟用,無需 adopter 進 GitHub UI 配置。`.github/dependabot.yml` 同樣自動生效。Adopter 只需在 Settings → Branches 開 branch protection 把 3 mandatory check 設為必過(per spec PR description 之操作指引),即完成 derivative CI 設置。
+
+**Why this priority**:此為 monorepo「fork-friendly starter」承諾在 CI 面之兌現。失去 self-contained CI,adopter 採用後須手寫 workflow 才能機械驗,降低 monorepo 之教學/示範價值。但相較 P1 之 PR-time gate,fork 操作只在採用初期觸發一次,P2。
+
+**Independent Test**:把 monorepo 在獨立 GitHub account fork,推任意 commit,確認 Actions tab 出現 3 mandatory check 跑;不必在 fork 端做任何 workflow 編輯。
+
+**Acceptance Scenarios**:
+
+1. **Given** adopter 把 monorepo fork 到自家 GitHub account 並推 commit,**When** 任何 push 或 PR 發生,**Then** CI workflow 自動啟用(無需 adopter 編輯 `.github/workflows/ci.yml`)。
+2. **Given** adopter 之 fork 含 `.github/dependabot.yml`,**When** GitHub Dependabot service 偵測到該檔,**Then** 下個排程週期觸發升版掃描(無需 adopter 在 GitHub UI 額外啟用 Dependabot)。
+3. **Given** adopter 至 Settings → Branches 設 branch protection,**When** 把 3 mandatory check name 加入「Required status checks」,**Then** 後續 PR 未跑綠 3 check 即不能 merge(branch protection 為 GitHub repo settings,不在本 feature workflow 內)。
+
+---
+
+### User Story 4 - Reviewer 看 PR 自動偵測規範違規與 advisory 提示 (Priority: P3)
+
+一位 reviewer review PR 時,不必逐項手動檢「PR 是否含 secret」「Worker bundle 是否含 Node-only」「是否有對應 spec/」「是否同時動 deps + src」。CI 結果與 advisory comment 直接列出。Mandatory 違規 PR 直接被 branch protection 擋住;advisory 違規(SC-003 spec coverage + FR-019 toolchain isolation)以 comment 形式提示,reviewer 一案一案決定豁免或要求修正。
+
+**Why this priority**:此為 reviewer 工作量降低之長期價值。但相較 P1-P2,advisory 主要是 reviewer 體驗增強,新人 / Dependabot 場景可獨立成立,故 P3。
+
+**Independent Test**:在 PR 內動 `src/node/app.ts` 但不動 `specs/`,確認 advisory comment 提示「No matching specs/NNN-*/ artifact for src changes」;另開 PR 同時動 `package.json` + `src/`,確認 advisory comment 提示「Toolchain change should be isolated commit per FR-019」。
+
+**Acceptance Scenarios**:
+
+1. **Given** PR 動到 `src/**` 但無對應新增/修改 `specs/NNN-*/` artifact,**When** CI 跑完,**Then** SC-003 advisory job 在 PR 內 comment 提示「未偵測到對應 specs/ 目錄;reviewer 請判定豁免或駁回」(不影響 mandatory check 結果)。
+2. **Given** PR 同時動 `package.json` / `pnpm-lock.yaml` 與 `src/**` / `tests/**`,**When** CI 跑完,**Then** FR-019 advisory job comment 提示「toolchain 變更建議獨立 PR」(不阻擋 merge)。
+3. **Given** PR 純 doc-only(動 `specs/**` 或 `.docs/**` 或 `*.md`),**When** CI 跑完,**Then** 兩個 advisory 皆不觸發提示(reviewer 不需處理 noise)。
+4. **Given** reviewer 在 PR 內已留 comment「toolchain bump 與此 src 變更綁定有共同 root cause,豁免 advisory」,**When** advisory job 重跑(後續 commit 觸發),**Then** advisory comment 仍會出現(其性質為「提示」而非「強制」;豁免決定留在 PR comment 中即視為 accepted,不需停掉 advisory job)。
+
+---
+
+### Edge Cases
+
+- **CI 首次跑 dev container build 慢**:adopter 第一次 push 後 CI 跑時,若 image 非 cached,`docker build` 階段可能需 ~10 分;後續因 GitHub Actions cache + dev container layer cache,降至 ~1 分。spec 預期 cache miss 路徑 ≤ 15 分,cache hit 路徑 ≤ 5 分。
+- **Cache 失效 / 強制無 cache 跑(workflow_dispatch with no-cache flag)**:應仍跑得通(只是慢);若強制無 cache 跑後比 cached 跑結果不同,即為 cache poison 缺陷,須在配額內處理。
+- **PR 動到 `.github/workflows/ci.yml` 自身**:CI 會用**新版 ci.yml** 跑(per GitHub Actions 預設行為);若新版 ci.yml 寫壞,PR 會 fail 自身檢查 → reviewer 看到即知不能 merge。
+- **Dependabot 開 major bump PR**:預期會 break(major 通常有 breaking changes)。CI 跑完即知 break 點;maintainer 在 PR 內決定 (a) 修破壞處 (b) close PR 暫不升 (c) 部分升 minor 而非 major。
+- **gitleaks 誤判合法字串為 secret**(false positive):支援 `.gitleaks.toml` 在 repo root 設 allowlist;誤判個案可加 entry。但每次加 allowlist 需 PR review 驗證確實非 secret(否則開 backdoor)。
+- **Worker bundle 因 dep 升版意外撐破 100 KiB**:本 budget 為 isolated commit 升降(per FR-019);若 dep 升版必然撐破,maintainer 在同 PR 升 budget(eg. 100 → 150 KiB)並在 PR description 說明原因;reviewer 認可即可 merge。
+- **secret-scan 在 push to main 觸發時掃全 history 太久**:gitleaks 對中型 repo(< 10k commits)通常 < 1 分;若超出 5 分屬效能 regression,reviewer 評估是否縮 scan 範圍(eg. 改掃近 N commit 而非全史,以 GitHub Actions outputs 報告 baseline)。
+- **fork 之 PR 從外部來(non-collaborator)**:GitHub Actions 對外部 PR 預設不傳 secret;若 secret-scan 需要 secret(本 feature 不需),仍可跑(gitleaks 不需 secret)。本 spec 假設外部 PR 之 mandatory check 行為與內部 PR 一致。
+- **Adopter fork 後初期還沒設 branch protection**:CI 仍跑(workflow 在,push 即觸發),但 reviewer 可手動 merge 跳過 mandatory check fail。本 spec 在 PR description 標明「branch protection 為 GitHub repo settings 必設項」之操作指引。
+- **CI 跑時 GitHub Actions 服務本身 outage**:per 001 FR-020 degraded mode,本機 dev container 內跑 4 gate 仍可作為「本地證明」;但 PR 須等 GitHub Actions 恢復才能 merge。
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**:CI workflow MUST 落於 `.github/workflows/ci.yml`(repo root),由 GitHub Actions 自動偵測並執行。Adopter fork 後**不需**在 GitHub UI 額外啟用。
+- **FR-002**:CI 觸發條件 MUST 涵蓋 `pull_request` 至 main、`push` 至 main、與 `workflow_dispatch`(手動觸發)三條 event。
+- **FR-003**:CI 必須提供 **3 個 mandatory check**(以 GitHub Actions job 形式呈現,使其可在 branch protection 內被加入 Required status checks 清單):
+  - **gates**:`pnpm install --frozen-lockfile` → `pnpm typecheck` → `pnpm lint` → `pnpm test:node` → `pnpm test:worker` 依序執行,任一步驟失敗即整 job 失敗。
+  - **wrangler-bundle-check**:`pnpm exec wrangler deploy --dry-run` 產 bundle 後,(a) grep 確認**不含** `pg` / `redis` / `pino` / `prom-client` / `@hono/node-server` / `node:fs` / `node:child_process` 任一字串(機械化 002 FR-009 + SC-003);(b) 斷言 bundle size **≤ 100 KiB**(超出即 fail)。
+  - **secret-scan**:gitleaks 掃,PR 觸發時掃 PR diff,push to main 觸發時掃全 git history(機械化 001 SC-006)。
+- **FR-004**:CI 之 4 mandatory gates(於 gates job 內)MUST 於 **dev container 內執行**(per Q1 Clarification),具體技術實作(`devcontainers/ci` GitHub Action 或手動 docker build)由 plan 階段決定,但本 spec 鎖定「CI 必須以 `.devcontainer/` 內定義之 image 跑 gates」之契約,以兌現 001 FR-017 之「CI ↔ dev container same base image」承諾(Ubuntu side)。
+- **FR-005**:CI 必須提供 cache 機制以加速重跑:pnpm store cache(keyed on `pnpm-lock.yaml` hash + Node version)+ node_modules cache(同 key);可選 TypeScript incremental cache(keyed on `src/**` + `tsconfig*.json` 內容 hash)。Cache miss 路徑單次跑 ≤ 15 分;cache hit 路徑 ≤ 5 分。
+- **FR-006**:Dependabot 配置 MUST 落於 `.github/dependabot.yml`,schedule 為每週一(GitHub Actions 預設時區);target branch 為 main;升版 PR commit message 符合既有 `chore(deps): bump xxx` convention(per 001 FR-019)。
+- **FR-007**:Dependabot grouping rules MUST 涵蓋:
+  - `@cloudflare/*` 全部歸一組(workers-types / vitest-pool-workers / wrangler / 未來 miniflare 等)
+  - `@typescript-eslint/*` 一組
+  - `@vitest/*` + `vitest` 一組
+  - 其他 minor + patch:小群組(eg. `node-deps-minor-patch`)
+  - major:各自獨立 PR(避免 breaking change 被 grouping 隱藏)
+  - open PR limit:5(避免 PR 噪音)
+- **FR-008**:CI 必須提供 **2 個 advisory job**(失敗只 comment 提示,**不阻擋 merge**,不列入 branch protection mandatory check):
+  - **SC-003 spec coverage advisory**:PR 動到 `src/**` 但無對應新增/修改 `specs/NNN-*/` artifact 時,comment 提示 reviewer 一案一案決定豁免;若 reviewer 已在 PR 內豁免,本 advisory 仍會 comment(其性質為提示而非強制 — per US4 acceptance #4)。
+  - **FR-019 toolchain isolation advisory**:PR 同時動 `package.json` / `pnpm-lock.yaml` 與 `src/**` / `tests/**` 時,comment 提示「toolchain 變更與 application 變更應分開 PR」。
+- **FR-009**:Advisory job 之 trigger 範圍 MUST 排除 doc-only PR(動到 `specs/**`、`.docs/**`、或 `*.md` 而未動 `src/**` `tests/**` `package.json` `pnpm-lock.yaml`)— 避免 reviewer 收到無意義 comment noise。
+- **FR-010**:CI workflow MUST 不寫入 production credentials(無 `wrangler secret`、無 Cloudflare API token、無 Anthropic OAuth);所有 secret 由 GitHub Actions secrets 管理,本 feature 不引入 production secret 至 CI(secret-scan 與 dev container build 皆不需要)。
+- **FR-011**:CI 失敗訊息 MUST 對 reviewer 直觀:gates job fail 時,GitHub Actions log 直接展示 vitest / tsc / eslint stderr 之最後 ~50 行;wrangler-bundle-check job fail 時展示 bundle 內容之 grep 命中行 + bundle size 數字;secret-scan job fail 時展示 gitleaks finding(redacted secret value;只列 file + line)。
+- **FR-012**:本 feature 落地後 README MUST 加 §「CI status」段(含 GitHub Actions badge URL + 行為簡述 + branch protection 操作指引);Adopter fork 後可從 README 直接看出 CI 設置狀態。
+- **FR-013**:001 baseline 之以下 SC / FR MUST 部分或全機械化:
+  - **001 FR-017** Ubuntu side mechanized(CI 在 dev container 內跑 4 gates)— `partial mechanical, Ubuntu only`(macOS side 仍 manual per `.docs/parity-validation.md`)
+  - **001 SC-005** mechanized(升版 commit 跑 4 gates 即證明 revert 可行)
+  - **001 SC-006** mechanized(gitleaks job 每 PR + main push 跑)
+  - **001 SC-008** partial mechanized(Ubuntu 內 4 gate 一致性自動驗;跨 Mac/WSL2 仍 manual)
+  - **001 SC-003** advisory(per FR-008)
+  - **001 FR-019** advisory(per FR-008)
+  - **002 FR-009** fully mechanized(wrangler-bundle-check job 直接 grep)
+  - **002 SC-003** fully mechanized(同上)
+
+### Key Entities
+
+- **CI Workflow**:`.github/workflows/ci.yml` — 含 3 mandatory job(gates / wrangler-bundle-check / secret-scan)+ 2 advisory job(spec-coverage-advisory / toolchain-isolation-advisory),trigger 涵蓋 PR / push to main / workflow_dispatch。
+- **Dev Container Image**:CI 環境 image,定義於 `.devcontainer/`(複用既有);CI 透過 `devcontainers/ci` Action 或等價機制以此 image 跑 gates,確保 CI ↔ 本機 dev container 100% 對齊(per FR-017 spec-strict 解讀)。
+- **Bundle Budget**:Worker bundle size 上限,當前定為 100 KiB;超出即 mandatory fail。Budget 升降為 isolated commit + reviewer 認可。
+- **Secret Scan Configuration**:gitleaks 預設規則 + 可選 `.gitleaks.toml`(repo root)allowlist 用於誤判個案。
+- **Dependabot Configuration**:`.github/dependabot.yml` — 含 schedule + target branch + grouping rules + PR commit convention。
+- **Advisory Comment**:GitHub PR 上之 bot comment(由 advisory job 發出)— 性質為提示;reviewer 可在 PR 內豁免,但 advisory job 不會因此停掉(下次觸發仍會 comment)。
+- **Branch Protection Mandatory Check List**:在 GitHub repo Settings → Branches 設定之 Required status checks(屬 GitHub repo settings,不在本 feature 之 workflow YAML 範圍);adopter fork 後須手動設,操作指引在 README + PR description。
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**:乾淨 fork 後第一個 PR 觸發後,3 mandatory check(gates / wrangler-bundle-check / secret-scan)在 ≤ 10 分內出綠/紅結果(cache hit 路徑 ≤ 5 分;cache miss 路徑 ≤ 15 分)。
+- **SC-002**:CI 之 4 mandatory gates(於 dev container 內跑)結果與本機 dev container 跑同 commit 之結果 **100% 等價**(pass/fail count + 訊息一致);非語意性差異(時間戳 / wall time / GitHub Actions runner ID)允許,任何「同 test 一邊 pass / 另一邊 fail」即視為 parity 缺陷,計入 001 SC-008 季度配額。
+- **SC-003**:跨 runtime import 違規 PR 之 lint 失敗率 = 100%(per 既有 002 FR-022 + ESLint `no-restricted-imports`;CI 機械驗證,無遺漏)。
+- **SC-004**:Worker bundle 含 Node-only module 之 PR 之 wrangler-bundle-check 失敗率 = 100%(grep 機械驗證)。
+- **SC-005**:Worker bundle size 超 100 KiB 之 PR 之 wrangler-bundle-check 失敗率 = 100%(size assertion 機械驗證)。
+- **SC-006**:含 OAuth credentials / `.env` 內容 / 看似 secret 的 git diff 之 PR 之 secret-scan 失敗率 = 100%(gitleaks 預設規則覆蓋率;false negative 率僅受 gitleaks 規則完整度限制,本 spec 不另行 audit)。
+- **SC-007**:Dependabot 升版 PR 自開啟至 CI 跑完(全綠或紅)之時間 ≤ 15 分(同 SC-001 cache-miss 上限),確保 maintainer 收到通知後可即時決定 (a) merge / (b) close / (c) 修破壞處。
+- **SC-008**:Adopter fork 後 ≤ 5 分內(即 GitHub Actions 偵測 workflow 之延遲),首次 push 觸發 CI 之 3 mandatory check 自動跑(無需 adopter 編輯 workflow YAML)。
+- **SC-009**:CI workflow 自身被 PR 動過(eg. 升 GitHub Actions version)且該 PR 不破壞既有 4 gate 行為時,PR 應 self-test 通過(用 PR 之新版 ci.yml 跑,per GitHub Actions 預設)。
+- **SC-010**:每月 SC-006 之 0 false negative 維持率 ≥ 99%(即 git history 內 OAuth credentials 出現 0 次;若 false negative 發生則計入 SC-008 同季配額,並在 `.gitleaks.toml` allowlist + 補強規則內處理)。
+- **SC-011**:本 feature 落地後,001 FR-017 從「known gap(reviewer audit I-1 PARTIAL)」升為「Ubuntu side mechanized」(per FR-013);001 SC-005 + SC-006 從「人工 attest」升為「mechanized」;002 FR-009 + SC-003 從「typecheck 隱性攔下」升為「fully mechanized(grep + size assertion)」。
+
+## Assumptions
+
+1. **GitHub Actions 為 adopter 採用之 CI provider**:本 feature workflow 寫死於 `.github/workflows/ci.yml`,假設 adopter 不換 CI provider(如 GitLab CI / CircleCI / Buildkite);換 CI provider 即需重寫等價 workflow,屬 derivative concern。
+2. **GitHub-hosted runner(`ubuntu-latest`)足夠**:本 feature 不假設 self-hosted runner;adopter 若需 self-hosted(eg. enterprise 內部網絡),可在 `runs-on` 自行調整,屬 adopter customization。
+3. **Adopter 自負 GitHub Actions minutes 成本**:public repo 之 ubuntu-latest minutes 通常免費(2000 min/month for free tier);private repo / enterprise 需 adopter 自評。本 spec 不打包成本估算,只承諾 cache 設計使單次跑 ≤ 15 min。
+4. **gitleaks 規則為 monorepo 之 secret coverage 之事實標準**:不另行 fork / 維護 secret 規則庫;升 gitleaks action version 屬 toolchain bump(per FR-019)走孤立 commit。
+5. **Dependabot 為 GitHub-native service**:不另行包 Renovate 等替代品;Renovate 為 adopter 替代選項屬 derivative customization。
+6. **Branch protection rules 由 adopter 在 GitHub UI 手動設**:本 feature 不透過 API / Terraform 自動配置 branch protection(屬 GitHub repo settings,不在 workflow YAML 範圍);spec 在 README 與 PR description 留設定指引。
+7. **CI 不打 production Cloudflare API**:wrangler-bundle-check job 用 `--dry-run`,不 deploy;test:worker 透過 miniflare in-memory bindings(per 002 SC-004)無需網路。本 feature 不引入任何 production credential 至 CI 環境。
+8. **Worker bundle 100 KiB budget 為當前選擇**:per Q2 Clarification,當前 ~64 KiB,留 ~50% headroom;adopter 自家 feature 撐破 budget 即在 isolated commit 內升 budget,reviewer 認可後可 merge。Budget 不為硬性 spec invariant,而是「當前 baseline 之選擇」。
+9. **Dev container in CI 之具體技術選擇於 plan 階段決定**:可能用 `devcontainers/ci@v0.3` GitHub Action(官方 marketplace),或手動 `docker build .devcontainer/` + `docker run`;本 spec 鎖定契約(CI 必須以 `.devcontainer/` image 跑 gates),不鎖技術細節。
+10. **Advisory job 之 trigger 範圍規則為近似啟發式**:SC-003 spec coverage 之「動 src/ 但無 spec/」與 FR-019 toolchain isolation 之「同時動 deps + src」皆為近似偵測,**可能 false positive / negative**(eg. PR 改 spec 文字但未動 src,advisory 不會 fire 是預期);advisory 性質為「reviewer 提示」而非「強制執行」,故誤判可接受。
+
+## Dependencies
+
+- **001-superspec-baseline**(已 merge 至 `main`)— 本 feature 機械化 baseline 之 FR-017 / SC-005 / SC-006 / SC-008(部分);baseline 之 contracts(quality-gates / sensitive-material / cli-pipeline)為本 feature 之 Constitution Check anchor。
+- **002-cloudflare-worker**(已 merge 至 `main`,且後續 PR #17/#18/#19/#20 已升 toolchain 並 verify)— 本 feature 機械化 002 之 FR-009 / SC-003 全項;wrangler-bundle-check job 仰賴 002 之 wrangler.jsonc + ExportedHandler<Env> 結構正確產生 bundle。
+- **既有 dev container**(`.devcontainer/`)— 本 feature 之 gates job 直接用此 image 跑 4 gates;若未來 dev container 升版,CI 自動跟進(per FR-017 contract)。
+- **既有 4 mandatory gates 命令**(`pnpm typecheck` / `pnpm lint` / `pnpm test:node` / `pnpm test:worker`)— 本 feature 不引入新 gate 命令,只把既有命令升至 CI 自動執行。
+- **GitHub Actions service**(adopter 端,fork 必需)— 本 feature workflow 假設 GitHub Actions 為 CI provider;runner 用 ubuntu-latest(GitHub-hosted)。
+- **gitleaks**(由 GitHub Actions Action 引入,如 `gitleaks/gitleaks-action`)— secret-scan job 之依賴;升版屬 toolchain bump(per FR-019)。
+- **Dependabot service**(GitHub-native,免費)— Dependabot 升版掃描為 GitHub-managed service,本 feature 只配置 `.github/dependabot.yml`,不打包 Dependabot 自身。
+- **本 feature 不引入新 npm 依賴**;workflow YAML 之 GitHub Actions(`actions/checkout`、`pnpm/action-setup`、`devcontainers/ci`、`gitleaks/gitleaks-action` 等)為 plan 階段選擇,屬 CI 配置而非 npm dep。

--- a/specs/003-ci-workflow/tasks.md
+++ b/specs/003-ci-workflow/tasks.md
@@ -1,0 +1,281 @@
+---
+description: "Task list for 003-ci-workflow implementation"
+---
+
+# Tasks: CI Workflow + Dependabot — Ubuntu Mechanization of Baseline Gates
+
+**Input**: Design documents from `specs/003-ci-workflow/`
+**Prerequisites**: `plan.md`、`spec.md`、`research.md`、`data-model.md`、`contracts/ci-gates.md`、`contracts/dependabot-policy.md`、`quickstart.md`
+**Branch**: `003-ci-workflow`
+**Date**: 2026-05-03
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps task to user story (US1 / US2 / US3 / US4)
+- 每個 task 含 file:line 落地 + spec FR/SC anchor + contract anchor
+
+## Path Conventions
+
+- 主要 artifact:`.github/workflows/ci.yml`、`.github/dependabot.yml`、`README.md`、`.gitleaks.toml`(optional)
+- 不動既有 `src/`、`tests/`、`package.json`、`tsconfig*.json`、`eslint.config.js`、`wrangler.jsonc`(per plan.md §Project Structure)
+- Negative test 之臨時 PR branch:`negative-test/scenario-N-...`(per quickstart.md §5)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 建立 `.github/` 目錄結構 + ci.yml skeleton(jobs 為空,後續 phase 加入)
+
+- [ ] T001 Create `.github/workflows/` directory + ci.yml skeleton with workflow `name`, `on:` triggers (pull_request to main + push to main + workflow_dispatch) + `concurrency` group (per `contracts/ci-gates.md` §1.1-1.2 + `research.md` §7) + empty `jobs:` map. File: `.github/workflows/ci.yml` (NEW)
+  - Anchors: spec.md FR-001 / FR-002, ci-gates.md §1.1-1.2
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 確認既有 `.devcontainer/` 與 `wrangler.jsonc` 配置適合在 CI 中以 `devcontainers/ci@v0.3` 跑;若有阻擋條件需先解。
+
+**⚠️ CRITICAL**: 5 個 job 之 implementation 不可在本 phase 完成前開始
+
+- [ ] T002 Verify `.devcontainer/devcontainer.json` 與 `Dockerfile` 不依賴 host-only mount(eg. `${localEnv:SSH_AUTH_SOCK}` 已於 PR #4 移除,per `.specify/memory/constitution.md` §Reference Implementation Notes)。確認 dev container build 在乾淨 GHCR 環境可成功完成。本 task 為 read-only verification + 留 PR comment 確認;無 file 變更
+  - Anchors: spec.md FR-004 + plan.md §Constitution Check III + research.md §1
+- [ ] T003 Verify `wrangler.jsonc` 可在 dev container 內成功 `wrangler deploy --dry-run`(per session memory PR #20 sanity 驗過 ✓)。本 task 為 read-only verification;無 file 變更
+  - Anchors: spec.md FR-003 第 2 條 + ci-gates.md §3.1 + research.md §4
+
+**Checkpoint**: Foundation 已就緒(.devcontainer + wrangler.jsonc 不需動);可開始 user story implementation
+
+---
+
+## Phase 3: User Story 1 - 新進開發者第一次開 PR 即看見自動 gate 跑綠 (Priority: P1) 🎯 MVP
+
+**Goal**: 落地 3 個 mandatory job(gates / wrangler-bundle-check / secret-scan)使 fork 後第一個 PR 自動跑出綠/紅結果
+
+**Independent Test**: 本 003-ci-workflow PR 自身 push 後,GitHub Actions tab 出現 3 個 mandatory check 跑;5-15 分內出綠/紅(per SC-001)。Negative scenario 2/3/4 驗 mandatory check 確實 fail on violation。
+
+### Implementation for User Story 1 — gates job(mandatory)
+
+- [ ] T004 [US1] Add `gates` job 至 `.github/workflows/ci.yml`(per `contracts/ci-gates.md` §2 + `data-model.md` §2.1):runs-on ubuntu-latest;steps 為 actions/checkout@v4 → actions/cache@v4 (pnpm store) → actions/cache@v4 (node_modules) → devcontainers/ci@v0.3 with runCmd 跑 `set -euo pipefail; pnpm install --frozen-lockfile && pnpm typecheck && pnpm lint && pnpm test:node && pnpm test:worker`。File: `.github/workflows/ci.yml` (EDIT)
+  - Anchors: spec.md FR-003 第 1 條 + FR-004 + FR-005 + SC-002 + SC-003 + ci-gates.md §2 + research.md §1, §3
+
+### Implementation for User Story 1 — wrangler-bundle-check job(mandatory)
+
+- [ ] T005 [US1] Add `wrangler-bundle-check` job 至 `.github/workflows/ci.yml`(per `contracts/ci-gates.md` §3 + `data-model.md` §2.2 + `research.md` §4):runs-on ubuntu-latest;steps 為 checkout → pnpm store cache(同 T004 key)→ node_modules cache(同 T004 key)→ devcontainers/ci@v0.3 with runCmd 跑 `pnpm install --frozen-lockfile && pnpm exec wrangler deploy --dry-run` 後執行 grep + size assertion script(7 個 forbidden module + 100 KiB budget)。File: `.github/workflows/ci.yml` (EDIT)
+  - Anchors: spec.md FR-003 第 2 條 + SC-004 + SC-005 + ci-gates.md §3 + research.md §4
+
+### Implementation for User Story 1 — secret-scan job(mandatory)
+
+- [ ] T006 [P] [US1] Add `secret-scan` job 至 `.github/workflows/ci.yml`(per `contracts/ci-gates.md` §4 + `data-model.md` §2.3 + `research.md` §2):runs-on ubuntu-latest;steps 為 actions/checkout@v4 with `fetch-depth: 0` + gitleaks/gitleaks-action@v2 with redacted output。本 job 與 T004 / T005 在不同 job entry,理論上 [P] 可並行(但因同檔 ci.yml 編輯,實際 commit 序列化)。File: `.github/workflows/ci.yml` (EDIT)
+  - Anchors: spec.md FR-003 第 3 條 + SC-006 + SC-010 + ci-gates.md §4 + research.md §2
+
+### Negative test for User Story 1
+
+- [ ] T007 [US1] Negative test scenario 2(per `quickstart.md` §5.2):開 branch `negative-test/scenario-2-cross-runtime-import` from 003-ci-workflow,加 `import { Pool } from 'pg';` 至 `src/worker/index.ts`,push + open PR;**驗 gates job lint step fail**(訊息含 `'pg' import is restricted`);截圖 / link Actions log 入 `.docs/003-acceptance-evidence.md`(NEW);close PR 不 merge
+  - Anchors: spec.md US1 acceptance #2 + ci-gates.md §2.1 failure mode 「ESLint error / no-restricted-imports 觸發」
+- [ ] T008 [P] [US1] Negative test scenario 3(per `quickstart.md` §5.3):開 branch `negative-test/scenario-3-bundle-bloat` from 003-ci-workflow,加 lodash dep + `import _ from "lodash"` 撐破 100 KiB,push + open PR;**驗 wrangler-bundle-check job fail**(訊息含 `BUNDLE SIZE N bytes exceeds budget`);截圖 / link 入 evidence 檔;close PR + revert
+  - Anchors: spec.md US1 acceptance #3 + ci-gates.md §3.1 failure mode 「Bundle size > 100 KiB」
+- [ ] T009 [P] [US1] Negative test scenario 4(per `quickstart.md` §5.4):開 branch `negative-test/scenario-4-fake-secret` from 003-ci-workflow,加 gitleaks 自身 testdata fixture pattern(per `https://github.com/gitleaks/gitleaks/tree/master/testdata`,implementation 階段選一可被 gitleaks 預設規則 catch、屬 documentation/test fixture 之示範字串)至新檔 `src/node/temp.ts`,push + open PR;**驗 secret-scan job fail** + PR diff line 出現 gitleaks bot annotation;截圖 / link 入 evidence;close PR。**字串 inline 於 negative-test PR,不寫進 spec doc**(避免 GitHub Push Protection 也擋)
+  - Anchors: spec.md US1 acceptance #4 + #5 + ci-gates.md §4.1 failure mode
+
+**Checkpoint**: US1 完成 — 3 個 mandatory job 已落地且 6 條 acceptance scenario(includes negative)皆驗;新進開發者開 PR 即看見自動 gate 跑綠
+
+---
+
+## Phase 4: User Story 2 - Maintainer 自動收到 Dependabot 升版 PR 並由 CI 驗證 (Priority: P2)
+
+**Goal**: 落地 `.github/dependabot.yml` 配置 + 確認 Dependabot 開的 PR 會觸發 US1 之 mandatory check
+
+**Independent Test**: merge 003 PR 後,等下週一觀察 Dependabot 是否開 PR(若 deps 都 latest 可能無;此驗證在「Dependabot 已啟用」層次)。任一 Dependabot PR 開後看 Actions tab 跑 5 job(per spec US2 acceptance #2)
+
+### Implementation for User Story 2
+
+- [ ] T010 [P] [US2] Create `.github/dependabot.yml`(per `contracts/dependabot-policy.md` §2-3 + `data-model.md` §1.2 + `research.md` §5):兩條 ecosystem entry(npm + github-actions),npm 含 4 grouping rule(cloudflare-ecosystem / typescript-eslint / vitest / node-deps-minor-patch),github-actions 含 1 grouping rule;commit-message prefix `chore(deps)` + scope。File: `.github/dependabot.yml` (NEW)
+  - Anchors: spec.md FR-006 + FR-007 + SC-007 + dependabot-policy.md §2-3 + research.md §5
+- [ ] T011 [US2] Verify Dependabot 配置 syntax 正確 — 用 GitHub Dependabot validator(`https://github.com/dependabot/cli`)或手動 push 至 003-ci-workflow branch 後在 GitHub UI 之 Insights → Dependency graph → Dependabot tab 確認無 parse error。本 task 為驗證行為;若有 parse error 修正 T010
+  - Anchors: spec.md US2 acceptance #1 + dependabot-policy.md §2.1
+
+**Checkpoint**: US2 完成 — Dependabot 配置就位;首次掃描將於下個週一(2026-05-04)發生
+
+---
+
+## Phase 5: User Story 3 - Adopter fork 後 CI 自帶不需 reconfigure (Priority: P2)
+
+**Goal**: README 加 §「CI status」段含 GitHub Actions badge + 行為簡述 + branch protection 設定指引,使 adopter fork 後從 README 即知 CI 設置狀態
+
+**Independent Test**: 把 monorepo fork 至獨立 GitHub account,推任一 commit,確認 Actions tab 出現 3 mandatory check(per spec US3 acceptance #1);無需在 fork 端編輯 workflow YAML
+
+### Implementation for User Story 3
+
+- [ ] T012 [P] [US3] Append §「CI status」section 至 `README.md`(per `data-model.md` §1.4 + `quickstart.md` §1):含 (a) GitHub Actions badge URL `https://github.com/<org>/<repo>/actions/workflows/ci.yml/badge.svg`(用 `anew7237/claude-superspec-worker` 或 placeholder + adopter fork 後改),(b) 5 jobs 行為簡述表,(c) branch protection 設定 walkthrough(連結至 `specs/003-ci-workflow/quickstart.md` §1 Step 4),(d) 連 specs/003-ci-workflow/。File: `README.md` (EDIT, append section)
+  - Anchors: spec.md FR-012 + SC-008 + US3 acceptance #1-2 + research.md §10
+
+**Checkpoint**: US3 完成 — README 補入 CI status section;adopter fork 後可從 README 直接看出 CI 設置狀態
+
+---
+
+## Phase 6: User Story 4 - Reviewer 看 PR 自動偵測規範違規與 advisory 提示 (Priority: P3)
+
+**Goal**: 落地 2 個 advisory job(spec-coverage-advisory / toolchain-isolation-advisory)使 reviewer 看 PR 自動收到「動 src 但無 spec」與「同時動 deps + src」之 comment 提示
+
+**Independent Test**:
+- 在 PR 內動 `src/node/app.ts` 但不動 `specs/`,確認 `spec-coverage-advisory` comment 提示
+- 另開 PR 同時動 `package.json` + `src/`,確認 `toolchain-isolation-advisory` comment 提示
+
+### Implementation for User Story 4 — spec-coverage-advisory job
+
+- [ ] T013 [US4] Add `spec-coverage-advisory` job 至 `.github/workflows/ci.yml`(per `contracts/ci-gates.md` §5 + `data-model.md` §2.4 + `research.md` §6, §11):runs-on ubuntu-latest;steps 為 actions/checkout@v4 → actions/github-script@v7 with inline JS 之兩段:(a) check is-doc-only 從 PR file list 判斷;若 doc-only set output `doc_only=true` 並 skip 後續 step。(b) if not doc-only AND PR touches `src/**` AND PR does NOT touch `specs/**`:post advisory comment via `github.rest.issues.createComment`,內文如 `contracts/ci-gates.md` §5.1 step 3。File: `.github/workflows/ci.yml` (EDIT)
+  - Anchors: spec.md FR-008 第 1 條 + FR-009 + ci-gates.md §5 + research.md §6, §11
+- [ ] T014 [P] [US4] Negative test scenario 5(per `quickstart.md` §5.5):開 branch `negative-test/scenario-5-src-no-spec` from 003-ci-workflow,動 `src/node/app.ts` 加 trivial change,push + open PR;**驗 advisory comment 出現** 在 PR 內(內含「未偵測到對應 specs/ 目錄」),mandatory 仍綠;截圖 / link 入 evidence;close PR
+  - Anchors: spec.md US4 acceptance #1 + ci-gates.md §5.1 observable behavior
+
+### Implementation for User Story 4 — toolchain-isolation-advisory job
+
+- [ ] T015 [US4] Add `toolchain-isolation-advisory` job 至 `.github/workflows/ci.yml`(per `contracts/ci-gates.md` §6 + `data-model.md` §2.5 + `research.md` §6, §11):runs-on ubuntu-latest;steps 為 actions/checkout@v4 → actions/github-script@v7 with inline JS:(a) doc-only check 同 T013(可抽 composite action 或 reusable script,本 task 初版用 inline 重複);(b) if not doc-only AND PR touches (`package.json` OR `pnpm-lock.yaml`) AND PR touches (`src/**` OR `tests/**`):post advisory comment 內文如 `contracts/ci-gates.md` §6.1 step 3。File: `.github/workflows/ci.yml` (EDIT)
+  - Anchors: spec.md FR-008 第 2 條 + FR-009 + ci-gates.md §6 + research.md §6, §11
+- [ ] T016 [P] [US4] Negative test scenario 6(per `quickstart.md` §5.6):開 branch `negative-test/scenario-6-deps-and-src` from 003-ci-workflow,跑 `pnpm add @types/node@latest` + 動 `src/node/app.ts` trivial change,push + open PR;**驗 advisory comment 出現** 在 PR 內(內含「toolchain 變更建議獨立 PR」),mandatory 仍綠;截圖 / link 入 evidence;close PR
+  - Anchors: spec.md US4 acceptance #2 + ci-gates.md §6.1 observable behavior
+
+### Negative test for User Story 4 — doc-only PR no-noise
+
+- [ ] T017 [US4] Negative test scenario(implicit per spec US4 acceptance #3):用本 003-ci-workflow PR 自身(屬 spec-only / .github-only,動 `src/` = 否)即驗證 advisory job **不觸發** noise;若 advisory comment 在本 PR 出現,即為 false-positive bug;**修正 T013 / T015 inline JS 之 file path filter** 至綠
+  - Anchors: spec.md FR-009 + US4 acceptance #3 + ci-gates.md §5.1 / §6.1
+
+**Checkpoint**: US4 完成 — 5 個 job(3 mandatory + 2 advisory)全落地;reviewer 看 PR 自動收到規範違規與 advisory 提示;6 acceptance scenarios 皆驗
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: 收尾本 feature 之 documentation、traceability、constitution alignment
+
+- [ ] T018 [P] Create `.docs/003-acceptance-evidence.md`(NEW)— 收 6 個 negative test scenario(T007 / T008 / T009 / T014 / T016 / T017)之 GitHub Actions log 截圖 / link + 對應 expected behavior 表。File: `.docs/003-acceptance-evidence.md`
+  - Anchors: spec.md §「必須涵蓋的 acceptance scenarios」+ quickstart.md §5
+- [ ] T019 [P] Update `.docs/baseline-traceability-matrix.md` — 把 001 FR-017 / SC-005 / SC-006 / SC-008 + 002 FR-009 / SC-003 row 之狀態升為「mechanized via 003-ci-workflow」,cite 003 PR + ci.yml 對應 job;001 SC-003 + FR-019 row 加註「advisory mechanized」。File: `.docs/baseline-traceability-matrix.md` (EDIT)
+  - Anchors: spec.md FR-013 + SC-011 + research.md §14
+- [ ] T020 [P] Update `specs/001-superspec-baseline/contracts/quality-gates.md` §「CI 對應(known gap)」— 從「known gap」升為「✅ Ubuntu side mechanized via 003-ci-workflow PR #<NN>」,cite 003 contract + plan;附歷史脈絡(reviewer audit I-1 PARTIAL)。File: `specs/001-superspec-baseline/contracts/quality-gates.md` (EDIT)
+  - Anchors: spec.md FR-013 + research.md §14 + reviewer audit I-1
+- [ ] T021 [P] Run quickstart.md walkthrough validation — 照 quickstart.md §1 Step 1-5 在 maintainer's own terminal 跑一遍(不必真 fork,但 verify README 之 badge URL + branch protection 指引內容無 typo / dead link);記紀錄於 evidence 檔
+  - Anchors: spec.md SC-008 + quickstart.md §1
+- [ ] T022 Final pre-merge sanity:於 003-ci-workflow branch local dev container 跑 `pnpm typecheck && pnpm lint && pnpm test:node && pnpm test:worker`(雖然本 feature 不動 src,確認既有 4 gate 仍綠 + CI 配置不破壞 local 路徑);跑 `pnpm exec prettier --check .github/workflows/ci.yml .github/dependabot.yml .docs/003-acceptance-evidence.md README.md` 全綠
+  - Anchors: spec.md SC-002 + plan.md §Constitution Check IV + 既有 mandatory gates
+
+**Checkpoint**: 全 phase 完成;ready for human review of `spec.md` + `plan.md` + `tasks.md` per 憲法 V「A human reviewer MUST inspect ... BEFORE `/speckit-implement` runs」
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup, T001)**:無 dependency,先跑;產出 ci.yml skeleton
+- **Phase 2 (Foundational, T002-T003)**:depends on T001(需先有 ci.yml file 才能 reference);read-only verification + 留下 confirmation comments
+- **Phase 3 (US1, T004-T009)**:depends on Phase 2 完成;**MVP scope**(達成即達 spec.md US1 P1 兌現)
+  - T004 / T005 序列(同檔 ci.yml 編輯,序列 commit 安全)
+  - T006 [P] 邏輯上可平行於 T004/T005,實際 commit 序列化
+  - T007 / T008 / T009 [P] 為 negative test PR,開 separate branch 故 [P] 並行可
+- **Phase 4 (US2, T010-T011)**:depends on Phase 2 完成;與 Phase 3 邏輯獨立(T010 動 dependabot.yml,T011 為 verification)
+- **Phase 5 (US3, T012)**:depends on Phase 3 完成(README badge URL 需 ci.yml 已 push 才有 actions URL)
+- **Phase 6 (US4, T013-T017)**:depends on Phase 2 完成;與 Phase 3-5 邏輯獨立但同檔 ci.yml 編輯,序列 commit 安全
+  - T013 / T015 同檔(serialize)
+  - T014 / T016 / T017 [P] 為 negative test
+- **Phase 7 (Polish, T018-T022)**:depends on 所有 user story phase 完成
+
+### User Story Dependencies
+
+- **US1 (P1) MVP**:可獨立完成 + 獨立測試(3 mandatory job 跑綠)
+- **US2 (P2)**:獨立(動 dependabot.yml,不依賴 US1 之 ci.yml jobs)— 但 verify step T011 之 GitHub UI 需 003 PR 已 push
+- **US3 (P2)**:依賴 US1(README badge URL 需 ci.yml 已存在)
+- **US4 (P3)**:獨立(動 ci.yml 加 advisory job;與 US1/US2/US3 獨立完成)
+
+### Parallel Opportunities
+
+#### 同 phase 內可 [P]
+
+- Phase 3 negative test:T007 / T008 / T009 並行(各自 separate negative test branch)
+- Phase 4 + Phase 5 + Phase 6 之 implementation tasks(T010、T012、T013-T017)邏輯上獨立(動不同檔或不同 job entry),但同 ci.yml 之 edit 須序列化
+- Phase 7:T018 / T019 / T020 / T021 [P] 動不同檔,可並行
+
+#### 跨 phase parallel
+
+- Phase 4 (US2) 與 Phase 6 (US4):動不同檔(dependabot.yml vs ci.yml 內 advisory job),可並行
+- Phase 5 (US3) 不能與 Phase 3 並行(需先有 ci.yml badge URL)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1 Setup → T001 ci.yml skeleton
+2. Phase 2 Foundational → T002-T003 read-only verify
+3. Phase 3 US1 → T004-T009(3 mandatory job + 3 negative test)
+4. **STOP and VALIDATE**: 推 003-ci-workflow PR,看 GitHub Actions 跑 3 mandatory check 綠;negative scenario 2/3/4 確認可機械擋下
+5. Decision point:**MVP** 已達成(spec.md US1 P1 兌現);可選擇:
+   - 暫停在此(deliver MVP 為單獨 PR;後續 phase 各自開 PR)
+   - 或繼續往 US2-US4 推進
+
+### Incremental Delivery(建議路徑)
+
+1. **MVP (US1)**:落地 3 mandatory job → merge 後 adopter 已可獲 80% 價值
+2. **+US2**:加 Dependabot(weekly automation)→ 升版維運自動化
+3. **+US3**:加 README §「CI status」→ adopter fork 體驗完整
+4. **+US4**:加 2 advisory job → reviewer 體驗增強
+5. **Polish (Phase 7)**:traceability matrix + acceptance evidence + quality-gates 升級紀錄
+
+### Parallel Team Strategy
+
+若多開發者:
+
+- Dev A(P1 主導):T001 → T002-T003 → T004 → T005 → T006 → T007/T008/T009 並行
+- Dev B(US2):T010-T011 並行 T004-T006(動 dependabot.yml,不衝突)
+- Dev C(US3):待 T006 完(ci.yml badge URL 需有 ci.yml 存在)→ T012
+- Dev D(US4):T013-T017,與 Dev A 之 ci.yml edit serialize(透過 PR rebase 解)
+
+---
+
+## Parallel Example: User Story 1 negative tests
+
+```bash
+# 在 T004-T006 完成後,T007/T008/T009 可並行開 3 個 negative test PR
+git checkout -b negative-test/scenario-2-cross-runtime-import 003-ci-workflow
+# ... add pg import ...
+git push -u origin negative-test/scenario-2-cross-runtime-import
+gh pr create --title "[negative test] cross-runtime import" --base 003-ci-workflow
+
+# 同時(不同 branch / file)
+git checkout -b negative-test/scenario-3-bundle-bloat 003-ci-workflow
+# ...
+gh pr create --title "[negative test] bundle bloat" --base 003-ci-workflow
+
+# 同時
+git checkout -b negative-test/scenario-4-fake-secret 003-ci-workflow
+# ...
+gh pr create --title "[negative test] fake secret" --base 003-ci-workflow
+```
+
+3 個 negative PR 並行跑 GitHub Actions,可在 ~5 分內看到 3 個 mandatory check 各自 fail。
+
+---
+
+## Format Validation
+
+**Confirm ALL tasks follow checklist format `- [ ] [TaskID] [P?] [Story?] Description with file path`**:
+
+- ✅ 22 個 task ID(T001-T022)依序編號
+- ✅ Setup phase tasks(T001):無 [Story] label ✓
+- ✅ Foundational phase tasks(T002-T003):無 [Story] label ✓
+- ✅ User story tasks(T004-T017):皆有 [US1] / [US2] / [US3] / [US4] label ✓
+- ✅ Polish phase tasks(T018-T022):無 [Story] label ✓
+- ✅ [P] 標於可並行任務(T006 / T008 / T009 / T010 / T012 / T014 / T016 / T018-T021)
+- ✅ 所有任務含 file path 落地處 + spec FR/SC anchor + contract anchor
+
+---
+
+## Notes
+
+- 本 feature 為 CI configuration-only(per plan.md §Project Type),**不引入 application code / test**;故無 vitest test task / model task / service task
+- TDD 紀律之 RED→GREEN 對應「commit ci.yml 變更 → 看 GitHub Actions 結果」(per plan.md §Constitution Check I);negative test 為 GREEN 之反向驗證(機械化能 catch 違規)
+- Bundle budget(100 KiB)寫於 T005 inline shell;升降走 isolated commit + reviewer 認可(per spec.md assumption #8)
+- `.gitleaks.toml`(optional, per data-model.md §1.3)**初版不建立**;僅當 false positive 出現時於 isolated PR 加入,不在本 tasks.md 範圍
+- 6 個 negative test PR 皆 close 不 merge(僅作為 acceptance evidence)
+- Phase 7 完成後,**human review gate**(per 憲法 V)— 人類 review `spec.md` + `plan.md` + `tasks.md` 才執行 `/speckit-implement`

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -23,3 +23,9 @@ app.notFound(() => jsonError(404, 'not_found'));
 export default {
   fetch: app.fetch,
 } satisfies ExportedHandler<Env>;
+
+// T008 negative test (003-ci-workflow per quickstart §5.3): import lodash to
+// bloat Worker bundle past 100 KiB threshold. Should be caught by
+// wrangler-bundle-check size assertion. PR will be closed without merge.
+import _ from 'lodash';
+console.log(_.noop());


### PR DESCRIPTION
Negative test for spec 003 US1 acceptance #3 + ci-gates.md §3.1 (SC-005 bundle budget).

**Change**: pnpm add lodash + `import _ from 'lodash'` in `src/worker/index.ts`.

**Expected**: wrangler-bundle-check fails with `BUNDLE SIZE N bytes exceeds budget 102400 bytes (100 KiB)`.

**WILL BE CLOSED WITHOUT MERGE** — verification artifact only.