### PR TITLE
[negative test 5/T014] src without spec → expect spec-coverage-advisory comment

### DIFF
--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -79,3 +79,8 @@ app.get('/metrics', async (c) => {
   c.header('Content-Type', register.contentType);
   return c.body(await register.metrics());
 });
+
+// T014 negative test (003-ci-workflow per quickstart §5.5): trivial src/ change
+// without corresponding specs/NNN-*/ artifact. Should trigger
+// spec-coverage-advisory comment (advisory, does NOT block merge).
+// PR will be closed without merge.


### PR DESCRIPTION
Negative test for spec 003 US4 acceptance #1 + ci-gates.md §5.1 (advisory提示).

**Change**: `src/node/app.ts` trivial comment (no specs/ change).

**Expected**: 3 mandatory all green + spec-coverage-advisory job posts comment 提示.

**WILL BE CLOSED WITHOUT MERGE** — verification artifact only.