### PR TITLE
[negative test 6/T016] deps + src in same PR → expect toolchain-isolation-advisory comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/pg": "^8.11.10",
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
+    "ms": "^2.1.3",
     "pino-pretty": "^11.3.0",
     "prettier": "^3.3.3",
     "typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.2(eslint@9.39.4)
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       pino-pretty:
         specifier: ^11.3.0
         version: 11.3.0

--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -79,3 +79,8 @@ app.get('/metrics', async (c) => {
   c.header('Content-Type', register.contentType);
   return c.body(await register.metrics());
 });
+
+// T016 negative test (003-ci-workflow per quickstart §5.6): same PR touches
+// BOTH package.json + pnpm-lock.yaml AND src/**. Should trigger
+// toolchain-isolation-advisory comment (advisory, does NOT block merge).
+// PR will be closed without merge.


### PR DESCRIPTION
Negative test for spec 003 US4 acceptance #2 + ci-gates.md §6.1 (advisory提示).

**Change**: pnpm add -D ms (touches package.json + pnpm-lock.yaml) + `src/node/app.ts` trivial comment.

**Expected**: 3 mandatory all green + toolchain-isolation-advisory job posts comment 提示.

**WILL BE CLOSED WITHOUT MERGE** — verification artifact only.