### PR TITLE
[verify issue 33 T014] spec-coverage-advisory fires on src-only PR

### DIFF
--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -79,3 +79,7 @@ app.get('/metrics', async (c) => {
   c.header('Content-Type', register.contentType);
   return c.body(await register.metrics());
 });
+
+// Issue #33 verify: T014 spec-coverage-advisory — trivial src change without
+// corresponding specs/NNN-*/ artifact. Should trigger advisory comment
+// (advisory only, does NOT block merge). PR will be closed without merge.


### PR DESCRIPTION
Issue #33 follow-up — clean post-merge verification of spec-coverage-advisory job (per 003-ci-workflow ci-gates.md §5).

**Change**: trivial `src/node/app.ts` comment append. No `specs/` change.

**Expected**:
- 3 mandatory checks (gates / wrangler-bundle-check / secret-scan) all ✅
- `spec-coverage-advisory` job posts PR comment 「未偵測到對應 specs/ 目錄」
- `toolchain-isolation-advisory` job: skip / no comment (no deps change)
- PR mergeable (advisory does NOT block)

**WILL BE CLOSED WITHOUT MERGE** — verification artifact only.

After verify ✅, update `.docs/003-acceptance-evidence.md` §3.4 from DEFERRED → VERIFIED + close issue #33.