### PR TITLE
[verify issue 33 T016] toolchain-isolation-advisory fires on deps+src PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/pg": "^8.11.10",
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
+    "ms": "^2.1.3",
     "pino-pretty": "^11.3.0",
     "prettier": "^3.3.3",
     "typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.2(eslint@9.39.4)
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       pino-pretty:
         specifier: ^11.3.0
         version: 11.3.0

--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -79,3 +79,7 @@ app.get('/metrics', async (c) => {
   c.header('Content-Type', register.contentType);
   return c.body(await register.metrics());
 });
+
+// Issue #33 verify: T016 toolchain-isolation-advisory — same PR touches
+// BOTH package.json + pnpm-lock.yaml AND src/**. Should trigger advisory
+// comment (advisory only, does NOT block merge). PR will be closed.


### PR DESCRIPTION
Issue #33 follow-up — clean post-merge verification of toolchain-isolation-advisory job (per 003-ci-workflow ci-gates.md §6).

**Change**: `pnpm add -D ms` (touches package.json + pnpm-lock.yaml) + trivial `src/node/app.ts` comment append.

**Expected**:
- 3 mandatory checks (gates / wrangler-bundle-check / secret-scan) all ✅
- `toolchain-isolation-advisory` job posts PR comment 「toolchain 變更建議獨立 PR」
- `spec-coverage-advisory` job: skip / no comment (PR has spec-equivalent — actually since we touch src/ AND no specs/, advisory MAY fire here too. We accept both behaviors as long as toolchain-isolation fires.)
- PR mergeable (advisory does NOT block)

**WILL BE CLOSED WITHOUT MERGE** — verification artifact only.

After verify ✅, update `.docs/003-acceptance-evidence.md` §3.5 from DEFERRED → VERIFIED + close issue #33.